### PR TITLE
feat: add Heltec WSL V3 repeater observer build

### DIFF
--- a/variants/heltec_v3/platformio.ini
+++ b/variants/heltec_v3/platformio.ini
@@ -460,3 +460,43 @@ build_src_filter = ${Heltec_lora32_v3.build_src_filter}
   +<../examples/kiss_modem/>
 lib_deps =
   ${Heltec_lora32_v3.lib_deps}
+
+[env:Heltec_WSL3_repeater_observer_mqtt]
+extends = Heltec_lora32_v3
+upload_port = /dev/cu.usbserial-4
+build_flags =
+  ${Heltec_lora33_v3.build_flags}
+  -D ADVERT_NAME='"MQTT Observer"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+  -D WITH_MQTT_BRIDGE=1
+  -D MAX_MQTT_BROKERS=3
+  -D MQTT_MAX_PACKET_SIZE=1024
+  -D MQTT_DEBUG=1
+  -D MESH_PACKET_LOGGING=1
+  -D MESH_DEBUG=1
+  -D CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=y
+  -D ESP32_CPU_FREQ=160
+  -D MQTT_WIFI_TX_POWER=WIFI_POWER_19_5dBm
+  -D MQTT_WIFI_POWER_SAVE_DEFAULT=1
+#  -D WIFI_SSID='"ssid"'
+#  -D WIFI_PWD='"password"'
+#  -D MQTT_SERVER='"your-mqtt-broker.com"'
+#  -D MQTT_PORT=1883
+#  -D MQTT_USERNAME='"your-username"'
+#  -D MQTT_PASSWORD='"your-password"'
+build_src_filter = ${Heltec_lora32_v3.build_src_filter}
+  +<helpers/bridges/MQTTBridge.cpp>
+  +<helpers/MQTTMessageBuilder.cpp>
+  +<helpers/JWTHelper.cpp>
+  +<../examples/simple_repeater>
+lib_deps =
+  ${Heltec_lora32_v3.lib_deps}
+  ${esp32_ota.lib_deps}
+  elims/PsychicMqttClient@^0.2.4
+  bblanchon/ArduinoJson
+  arduino-libraries/NTPClient
+  JChristensen/Timezone
+  paulstoffregen/Time@1.6.1


### PR DESCRIPTION
Adds a new PlatformIO build environment for the Heltec WSL V3 as a repeater observer with MQTT bridge functionality.

To build the firmware:

```
FIRMWARE_VERSION=<version> ./build.sh build-firmware Heltec_WSL3_repeater_observer_mqtt
```