### PR TITLE
fix chimesh mqtt preset path

### DIFF
--- a/MQTT_IMPLEMENTATION.md
+++ b/MQTT_IMPLEMENTATION.md
@@ -104,6 +104,9 @@ The MQTT bridge uses a slot-based architecture with up to 6 concurrent connectio
 | `meshomatic` | us-east.meshomatic.net:443 | JWT (Ed25519) | WSS |
 | `cascadiamesh` | mqtt-v1.cascadiamesh.org:443 | JWT (Ed25519) | WSS |
 | `tennmesh` | mqtt.tennmesh.com:1883 | Username/password (fixed in firmware) | Plain MQTT |
+| `nashmesh` | mqtt://mqtt.nashme.sh:1883 | Username/password (fixed in firmware) | Plain MQTT |
+| `chimesh` | wss://mqtt.chimesh.org:443 | JWT (Ed25519) | WSS |
+| `meshat.se` | mqtts://mqtt.meshat.se:8883 | Username/password (fixed in firmware) | MQTT over TLS |
 | `custom` | User-configured | Username/Password | MQTT or WSS |
 | `none` | (disabled) | — | — |
 
@@ -231,6 +234,9 @@ Each slot (1-6) supports the following commands:
 - `set mqttN.preset meshomatic` - Set slot N to Meshomatic
 - `set mqttN.preset cascadiamesh` - Set slot N to CascadiaMesh
 - `set mqttN.preset tennmesh` - Set slot N to TennMesh (plain MQTT; same `meshcore/{iata}/...` topics as Analyzer US)
+- `set mqttN.preset nashmesh` - Set slot N to NashMesh
+- `set mqttN.preset chimesh` - Set slot N to ChicagolandMesh
+- `set mqttN.preset meshat.se` - Set slot N to Meshat.se
 - `set mqttN.preset custom` - Set slot N to custom broker (configure server/port/username/password)
 - `set mqttN.preset none` - Disable slot N
 - `set mqttN.server <hostname>` - Set custom server hostname for slot N

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -1333,7 +1333,7 @@ void CommonCLI::handleSetCmd(uint32_t sender_timestamp, char* command, char* rep
           }
         }
       } else {
-        strcpy(reply, "Error: valid presets are: analyzer-us, analyzer-eu, meshmapper, meshrank, waev, meshomatic, cascadiamesh, tennmesh, nashmesh, custom, none");
+        strcpy(reply, "Error: valid presets are: analyzer-us, analyzer-eu, meshmapper, meshrank, waev, meshomatic, cascadiamesh, tennmesh, nashmesh, chimesh, meshat.se, custom, none");
       }
     } else if (memcmp(subcmd, "server ", 7) == 0) {
       StrHelper::strncpy(_prefs->mqtt_slot_host[slot], &subcmd[7], sizeof(_prefs->mqtt_slot_host[slot]));

--- a/src/helpers/MQTTPresets.h
+++ b/src/helpers/MQTTPresets.h
@@ -112,7 +112,7 @@ static const MQTTPresetDef MQTT_PRESETS[MQTT_PRESET_COUNT] = {
   { "cascadiamesh",  "wss://mqtt-v1.cascadiamesh.org:443/mqtt",  "mqtt-v1.cascadiamesh.org", ISRG_ROOT_X1, MQTT_AUTH_JWT,  MQTT_TOPIC_MESHCORE, 0,    true,  55, nullptr, nullptr },
   { "tennmesh",      "mqtt://mqtt.tennmesh.com:1883",            nullptr,                   nullptr,      MQTT_AUTH_USERPASS, MQTT_TOPIC_MESHCORE, 0, true, 55, "mqttfeed", "tc2live" },
   { "nashmesh",      "mqtt://mqtt.nashme.sh:1883",               nullptr,                   nullptr,      MQTT_AUTH_USERPASS, MQTT_TOPIC_MESHCORE, 0, true, 55, "meshdev", "large4cats" },
-  { "chimesh",       "wss://mqtt.chimesh.org:443/mqtt",          "mqtt.chimesh.org",        ISRG_ROOT_X1, MQTT_AUTH_JWT,  MQTT_TOPIC_MESHCORE, 0,    true,  55, nullptr, nullptr },
+  { "chimesh",       "wss://mqtt.chimesh.org:443",               "mqtt.chimesh.org",        ISRG_ROOT_X1, MQTT_AUTH_JWT,  MQTT_TOPIC_MESHCORE, 0,    true,  55, nullptr, nullptr },
   { "meshat.se",     "mqtts://mqtt.meshat.se:8883",              nullptr,                   ISRG_ROOT_X1, MQTT_AUTH_USERPASS, MQTT_TOPIC_MESHCORE, 0, true, 55, "msh", "msh" },
 };
 


### PR DESCRIPTION
This PR removes the path from the `chimesh` preset. It is not necessary for `/mqtt` to be included to work.

Also, added are the missing presets from the cli message and docs.