### PR TITLE
feat: add Heltec tracker MQTT observer builds

### DIFF
--- a/MQTT_IMPLEMENTATION.md
+++ b/MQTT_IMPLEMENTATION.md
@@ -156,6 +156,12 @@ pio run -e Heltec_v3_repeater_observer_mqtt
 # Heltec V4
 pio run -e heltec_v4_repeater_observer_mqtt
 
+# Heltec Wireless Tracker v1.1 / v2
+pio run -e heltec_tracker_v1_1_repeater_observer_mqtt
+pio run -e heltec_tracker_v1_1_room_server_observer_mqtt
+pio run -e heltec_tracker_v2_repeater_observer_mqtt
+pio run -e heltec_tracker_v2_room_server_observer_mqtt
+
 # Station G2
 pio run -e Station_G2_repeater_observer_mqtt
 

--- a/boards/heltec_tracker_v1_1.json
+++ b/boards/heltec_tracker_v1_1.json
@@ -1,0 +1,40 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "esp32s3_out.ld",
+      "partitions": "default_8MB.csv"
+      },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_USB_CDC_ON_BOOT=1",
+      "-DARDUINO_USB_MODE=0",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=1"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [["0x303A", "0x1001"]],
+    "mcu": "esp32s3",
+    "variant": "heltec_tracker_v2"
+  },
+  "connectivity": ["wifi", "bluetooth", "lora"],
+  "debug": {
+    "default_tool": "esp-builtin",
+    "onboard_tools": ["esp-builtin"],
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": ["arduino", "espidf"],
+  "name": "Heltec Wireless Tracker v1.1",
+  "upload": {
+    "flash_size": "8MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 8388608,
+    "use_1200bps_touch": true,
+    "wait_for_upload_port": true,
+    "require_upload_port": true,
+    "speed": 921600
+  },
+  "url": "https://heltec.org/project/wireless-tracker/",
+  "vendor": "Heltec"
+}

--- a/variants/heltec_tracker_v2/LoRaFEMControl.cpp
+++ b/variants/heltec_tracker_v2/LoRaFEMControl.cpp
@@ -5,6 +5,7 @@
 
 void LoRaFEMControl::init(void)
 {
+#if defined(P_LORA_PA_POWER) && defined(P_LORA_KCT8103L_PA_CSD) && defined(P_LORA_KCT8103L_PA_CTX)
     pinMode(P_LORA_PA_POWER, OUTPUT);
     digitalWrite(P_LORA_PA_POWER, HIGH);
     rtc_gpio_hold_dis((gpio_num_t)P_LORA_PA_POWER);
@@ -16,32 +17,40 @@ void LoRaFEMControl::init(void)
     pinMode(P_LORA_KCT8103L_PA_CTX, OUTPUT);
     digitalWrite(P_LORA_KCT8103L_PA_CTX, lna_enabled ? LOW : HIGH);
     setLnaCanControl(true);
+#endif
 }
 
 void LoRaFEMControl::setSleepModeEnable(void)
 {
+#if defined(P_LORA_KCT8103L_PA_CSD)
     // shutdown the PA
     digitalWrite(P_LORA_KCT8103L_PA_CSD, LOW);
+#endif
 }
 
 void LoRaFEMControl::setTxModeEnable(void)
 {
+#if defined(P_LORA_KCT8103L_PA_CSD) && defined(P_LORA_KCT8103L_PA_CTX)
     digitalWrite(P_LORA_KCT8103L_PA_CSD, HIGH);
     digitalWrite(P_LORA_KCT8103L_PA_CTX, HIGH);
+#endif
 }
 
 void LoRaFEMControl::setRxModeEnable(void)
 {
+#if defined(P_LORA_KCT8103L_PA_CSD) && defined(P_LORA_KCT8103L_PA_CTX)
     digitalWrite(P_LORA_KCT8103L_PA_CSD, HIGH);
     if (lna_enabled) {
         digitalWrite(P_LORA_KCT8103L_PA_CTX, LOW);
     } else {
         digitalWrite(P_LORA_KCT8103L_PA_CTX, HIGH);
     }
+#endif
 }
 
 void LoRaFEMControl::setRxModeEnableWhenMCUSleep(void)
 {
+#if defined(P_LORA_KCT8103L_PA_CSD) && defined(P_LORA_KCT8103L_PA_CTX)
     digitalWrite(P_LORA_KCT8103L_PA_CSD, HIGH);
     rtc_gpio_hold_en((gpio_num_t)P_LORA_KCT8103L_PA_CSD);
     if (lna_enabled) {
@@ -50,6 +59,7 @@ void LoRaFEMControl::setRxModeEnableWhenMCUSleep(void)
         digitalWrite(P_LORA_KCT8103L_PA_CTX, HIGH);
     }
     rtc_gpio_hold_en((gpio_num_t)P_LORA_KCT8103L_PA_CTX);
+#endif
 }
 
 void LoRaFEMControl::setLNAEnable(bool enabled)

--- a/variants/heltec_tracker_v2/platformio.ini
+++ b/variants/heltec_tracker_v2/platformio.ini
@@ -58,6 +58,56 @@ lib_deps =
   ${sensor_base.lib_deps}
   adafruit/Adafruit ST7735 and ST7789 Library @ ^1.11.0
 
+[Heltec_tracker_v1_1]
+extends = Heltec_tracker_v2
+board = heltec_tracker_v1_1
+build_flags =
+  ${esp32_base.build_flags}
+  ${sensor_base.build_flags}
+  -I variants/heltec_tracker_v2
+  -D HELTEC_TRACKER_V1_1
+  -D ESP32_CPU_FREQ=240
+  -D USE_SX1262
+  -D RADIO_CLASS=CustomSX1262
+  -D WRAPPER_CLASS=CustomSX1262Wrapper
+  -D P_LORA_TX_LED=18
+  -D P_LORA_DIO_1=14
+  -D P_LORA_NSS=8
+  -D P_LORA_RESET=12
+  -D P_LORA_BUSY=13
+  -D P_LORA_SCLK=9
+  -D P_LORA_MISO=11
+  -D P_LORA_MOSI=10
+  -D LORA_TX_POWER=22
+  -D SX126X_DIO2_AS_RF_SWITCH=true
+  -D SX126X_DIO3_TCXO_VOLTAGE=1.8
+  -D SX126X_CURRENT_LIMIT=140
+  -D SX126X_RX_BOOSTED_GAIN=1
+  -D SX126X_REGISTER_PATCH=1
+  -D PIN_BOARD_SDA=6
+  -D PIN_BOARD_SCL=17
+  -D PIN_USER_BTN=0
+  -D PIN_TFT_SDA=42   ; SDIN
+  -D PIN_TFT_SCL=41   ; SCLK
+  -D PIN_TFT_DC=40    ; RS (register select)
+  -D PIN_TFT_RST=39   ; RES
+  -D PIN_TFT_CS=38
+  -D USE_PIN_TFT=1
+  -D PIN_VEXT_EN=3   ; Vext is connected to VDD which is also connected to OLED & GPS
+  -D PIN_VEXT_EN_ACTIVE=HIGH
+  -D PIN_TFT_LEDA_CTL=21 ; LEDK (switches on/off via mosfet to create the ground)
+  -D DISPLAY_ROTATION=1
+  -D PIN_GPS_RX=34
+  -D PIN_GPS_TX=33
+  -D PIN_GPS_RESET=35
+  -D PIN_GPS_RESET_ACTIVE=LOW
+  -D GPS_BAUD_RATE=115200
+  -D ENV_INCLUDE_GPS=1
+  -D PIN_ADC_CTRL=2
+  -D PIN_VBAT_READ=1
+build_src_filter = ${Heltec_tracker_v2.build_src_filter}
+lib_deps = ${Heltec_tracker_v2.lib_deps}
+
 [env:heltec_tracker_v2_repeater]
 extends = Heltec_tracker_v2
 build_flags =
@@ -118,6 +168,150 @@ build_src_filter = ${Heltec_tracker_v2.build_src_filter}
 lib_deps =
   ${Heltec_tracker_v2.lib_deps}
   ${esp32_ota.lib_deps}
+
+[env:heltec_tracker_v1_1_repeater_observer_mqtt]
+extends = Heltec_tracker_v1_1
+extra_scripts =
+  ${esp32_base.extra_scripts}
+  pre:scripts/generate_cert_bundle.py
+board_ssl_cert_source = adafruit-full
+board_build.embed_files = src/certs/x509_crt_bundle.bin
+build_flags =
+  ${Heltec_tracker_v1_1.build_flags}
+  -D DISPLAY_CLASS=ST7735Display
+  -D ADVERT_NAME='"MQTT Observer"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+  -D WITH_MQTT_BRIDGE=1
+  -D MAX_MQTT_BROKERS=3
+  -D MQTT_MAX_PACKET_SIZE=1024
+  -D MQTT_DEBUG=1
+  -D CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=y
+  -D MQTT_WIFI_TX_POWER=WIFI_POWER_11dBm
+build_src_filter = ${Heltec_tracker_v1_1.build_src_filter}
+  +<helpers/bridges/MQTTBridge.cpp>
+  +<helpers/MQTTMessageBuilder.cpp>
+  +<helpers/JWTHelper.cpp>
+  +<helpers/ui/ST7735Display.cpp>
+  +<../examples/simple_repeater>
+lib_deps =
+  ${Heltec_tracker_v1_1.lib_deps}
+  ${esp32_ota.lib_deps}
+  elims/PsychicMqttClient@^0.2.4
+  bblanchon/ArduinoJson
+  arduino-libraries/NTPClient
+  JChristensen/Timezone
+  paulstoffregen/Time@1.6.1
+
+[env:heltec_tracker_v2_repeater_observer_mqtt]
+extends = Heltec_tracker_v2
+extra_scripts =
+  ${esp32_base.extra_scripts}
+  pre:scripts/generate_cert_bundle.py
+board_ssl_cert_source = adafruit-full
+board_build.embed_files = src/certs/x509_crt_bundle.bin
+build_flags =
+  ${Heltec_tracker_v2.build_flags}
+  -D DISPLAY_CLASS=ST7735Display
+  -D ADVERT_NAME='"MQTT Observer"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+  -D WITH_MQTT_BRIDGE=1
+  -D MAX_MQTT_BROKERS=3
+  -D MQTT_MAX_PACKET_SIZE=1024
+  -D MQTT_DEBUG=1
+  -D CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=y
+  -D MQTT_WIFI_TX_POWER=WIFI_POWER_11dBm
+build_src_filter = ${Heltec_tracker_v2.build_src_filter}
+  +<helpers/bridges/MQTTBridge.cpp>
+  +<helpers/MQTTMessageBuilder.cpp>
+  +<helpers/JWTHelper.cpp>
+  +<helpers/ui/ST7735Display.cpp>
+  +<../examples/simple_repeater>
+lib_deps =
+  ${Heltec_tracker_v2.lib_deps}
+  ${esp32_ota.lib_deps}
+  elims/PsychicMqttClient@^0.2.4
+  bblanchon/ArduinoJson
+  arduino-libraries/NTPClient
+  JChristensen/Timezone
+  paulstoffregen/Time@1.6.1
+
+[env:heltec_tracker_v1_1_room_server_observer_mqtt]
+extends = Heltec_tracker_v1_1
+extra_scripts =
+  ${esp32_base.extra_scripts}
+  pre:scripts/generate_cert_bundle.py
+board_ssl_cert_source = adafruit-full
+board_build.embed_files = src/certs/x509_crt_bundle.bin
+build_flags =
+  ${Heltec_tracker_v1_1.build_flags}
+  -D DISPLAY_CLASS=ST7735Display
+  -D ADVERT_NAME='"Heltec Tracker Room Observer"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D ROOM_PASSWORD='"hello"'
+  -D WITH_MQTT_BRIDGE=1
+  -D MAX_MQTT_BROKERS=3
+  -D MQTT_MAX_PACKET_SIZE=1024
+  -D MQTT_DEBUG=1
+  -D CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=y
+  -D MQTT_WIFI_TX_POWER=WIFI_POWER_11dBm
+build_src_filter = ${Heltec_tracker_v1_1.build_src_filter}
+  +<helpers/bridges/MQTTBridge.cpp>
+  +<helpers/MQTTMessageBuilder.cpp>
+  +<helpers/JWTHelper.cpp>
+  +<helpers/ui/ST7735Display.cpp>
+  +<../examples/simple_room_server>
+lib_deps =
+  ${Heltec_tracker_v1_1.lib_deps}
+  ${esp32_ota.lib_deps}
+  elims/PsychicMqttClient@^0.2.4
+  bblanchon/ArduinoJson
+  arduino-libraries/NTPClient
+  JChristensen/Timezone
+  paulstoffregen/Time@1.6.1
+
+[env:heltec_tracker_v2_room_server_observer_mqtt]
+extends = Heltec_tracker_v2
+extra_scripts =
+  ${esp32_base.extra_scripts}
+  pre:scripts/generate_cert_bundle.py
+board_ssl_cert_source = adafruit-full
+board_build.embed_files = src/certs/x509_crt_bundle.bin
+build_flags =
+  ${Heltec_tracker_v2.build_flags}
+  -D DISPLAY_CLASS=ST7735Display
+  -D ADVERT_NAME='"Heltec Tracker Room Observer"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D ROOM_PASSWORD='"hello"'
+  -D WITH_MQTT_BRIDGE=1
+  -D MAX_MQTT_BROKERS=3
+  -D MQTT_MAX_PACKET_SIZE=1024
+  -D MQTT_DEBUG=1
+  -D CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=y
+  -D MQTT_WIFI_TX_POWER=WIFI_POWER_11dBm
+build_src_filter = ${Heltec_tracker_v2.build_src_filter}
+  +<helpers/bridges/MQTTBridge.cpp>
+  +<helpers/MQTTMessageBuilder.cpp>
+  +<helpers/JWTHelper.cpp>
+  +<helpers/ui/ST7735Display.cpp>
+  +<../examples/simple_room_server>
+lib_deps =
+  ${Heltec_tracker_v2.lib_deps}
+  ${esp32_ota.lib_deps}
+  elims/PsychicMqttClient@^0.2.4
+  bblanchon/ArduinoJson
+  arduino-libraries/NTPClient
+  JChristensen/Timezone
+  paulstoffregen/Time@1.6.1
 
 [env:heltec_tracker_v2_terminal_chat]
 extends = Heltec_tracker_v2


### PR DESCRIPTION
## PR Summary

### Overview

This PR adds MQTT observer firmware targets for both the Heltec Wireless Tracker v1.1 and Heltec Wireless Tracker v2 platforms.

The implementation introduces a dedicated PlatformIO board definition for Tracker v1.1, reuses the existing Tracker v2 variant where the hardware is compatible, and updates FEM handling so both hardware revisions build correctly.

### Changes

#### New MQTT Observer Build Targets

Added four new firmware environments:

- `heltec_tracker_v1_1_repeater_observer_mqtt`
- `heltec_tracker_v1_1_room_server_observer_mqtt`
- `heltec_tracker_v2_repeater_observer_mqtt`
- `heltec_tracker_v2_room_server_observer_mqtt`

#### Heltec Tracker v1.1 Support

- Added a PlatformIO board definition for Heltec Wireless Tracker v1.1.
- Reuses the existing Tracker v2 variant implementation where hardware behavior is identical.
- Minimizes code duplication between Tracker hardware revisions.

#### FEM Compatibility

Updated `LoRaFEMControl.cpp` so FEM control is only enabled when the required hardware is present.

This allows Tracker v1.1 to build successfully without the KCT8103L FEM control pins found on Tracker v2 hardware while preserving existing Tracker v2 behavior.

#### Documentation

- Updated `MQTT_IMPLEMENTATION.md` with the new MQTT observer firmware environments.

### Files Changed

- `boards/heltec_tracker_v1_1.json`
- `variants/heltec_tracker_v2/platformio.ini`
- `variants/heltec_tracker_v2/LoRaFEMControl.cpp`
- `MQTT_IMPLEMENTATION.md`

### Validation

Performed the following checks:

```bash
python3 -m json.tool boards/heltec_tracker_v1_1.json
git diff --check
```

Confirmed environment discovery detects all four new MQTT observer targets.

Build validation:

```bash
pio run -e heltec_tracker_v1_1_repeater_observer_mqtt
pio run -e heltec_tracker_v2_repeater_observer_mqtt
pio run -e heltec_tracker_v1_1_room_server_observer_mqtt
pio run -e heltec_tracker_v2_room_server_observer_mqtt
```

All PlatformIO builds completed successfully.

### Assessment

The change is low risk and primarily additive. Tracker v1.1 support is implemented using the existing Tracker v2 codebase where possible, while hardware-specific FEM functionality remains isolated to boards that support it.