### PR TITLE
Omit SNR/RSSI instead of publishing hardcoded 12.5/-65 when no radio data

### DIFF
--- a/src/helpers/MQTTMessageBuilder.cpp
+++ b/src/helpers/MQTTMessageBuilder.cpp
@@ -107,9 +107,7 @@ int MQTTMessageBuilder::buildPacketMessage(
   snprintf(len_str, sizeof(len_str), "%d", len);
   snprintf(packet_type_str, sizeof(packet_type_str), "%d", packet_type);
   snprintf(payload_len_str, sizeof(payload_len_str), "%d", payload_len);
-  snprintf(snr_str, sizeof(snr_str), "%.1f", snr);
-  snprintf(rssi_str, sizeof(rssi_str), "%d", rssi);
-  
+
   root["origin"] = origin;
   root["origin_id"] = origin_id;
   root["timestamp"] = timestamp;
@@ -122,8 +120,18 @@ int MQTTMessageBuilder::buildPacketMessage(
   root["route"] = route;
   root["payload_len"] = payload_len_str;
   root["raw"] = raw;
-  root["SNR"] = snr_str;
-  root["RSSI"] = rssi_str;
+  // Only emit SNR/RSSI when a real radio measurement is available. Callers with no raw
+  // radio data pass sentinels (<= -900); omitting the fields is honest about the gap,
+  // whereas the previous hardcoded 12.5/-65 fabricated plausible-looking values that
+  // polluted downstream RF analytics. Real measurements are always within sane ranges.
+  if (snr > -900.0f) {
+    snprintf(snr_str, sizeof(snr_str), "%.1f", snr);
+    root["SNR"] = snr_str;
+  }
+  if (rssi > -900) {
+    snprintf(rssi_str, sizeof(rssi_str), "%d", rssi);
+    root["RSSI"] = rssi_str;
+  }
   root["hash"] = hash;
   
   if (path && strlen(path) > 0) {
@@ -226,8 +234,8 @@ int MQTTMessageBuilder::buildPacketJSON(
     packet_type, route_str,
     packet->payload_len,
     raw_hex,
-    12.5f, // SNR - using reasonable default
-    -65,   // RSSI - using reasonable default
+    -999.0f, // SNR unknown — this overload reconstructs from the packet with no raw radio
+    -999,    // RSSI unknown — emitted by omitting the fields (was a fabricated 12.5/-65)
     hash_str,
     packet->isRouteDirect() ? path_str : nullptr,
     buffer, buffer_size


### PR DESCRIPTION
## What

When the MQTT observer has no real radio measurement for a packet, **omit** the `SNR`/`RSSI` fields
instead of publishing the hardcoded constants `12.5` / `-65`.

`src/helpers/MQTTMessageBuilder.cpp`:
- `buildPacketJSON()` (the no-raw-data overload) previously passed literal `12.5f` / `-65` to
  `buildPacketMessage()` ("// SNR/RSSI - using reasonable default"). It now passes sentinels.
- `buildPacketMessage()` emits the `SNR`/`RSSI` fields only when the value is real (sentinel `<= -900`
  → omit). Real measurements are always within sane radio ranges and serialize exactly as before.

## Why

`buildPacketJSONFromRaw()` carries the real per-packet SNR/RSSI, but the publish path falls back to
`buildPacketJSON()` whenever fresh raw radio data isn't available (no `raw_data` passed **and** the
global `_last_raw_*` snapshot older than 1 s — `MQTTBridge.cpp`). Because the MQTT publish runs on a
separate task that drains the queue asynchronously, that 1 s window is missed often.

The result is fabricated values indistinguishable from real readings. Measured against the public
CoreScope aggregator (200-packet samples per observer): the exact `(SNR=12.5, RSSI=-65)` pair appears
on **~3–20%** of packets for every observer running this bridge (and 0% on a non-bridge observer),
silently polluting network-wide RF analytics (`avgSnr`/`avgRssi`/`/analytics/rf`). Confirmed
end-to-end on a controlled node by correlating the serial RX log (real radio values) to the published
MQTT JSON by packet `hash`: published `12.5/-65` exactly where the radio reported real, different
values.

Omitting is honest about the gap — consumers can detect a missing field, but cannot detect a
fabricated reading.

## Testing

- Compiles clean: `pio run -e Heltec_v3_repeater_observer_mqtt` → SUCCESS (ESP32-S3 image built).
- Localized JSON-builder change; `buildPacketJSONFromRaw()` (the real-data path) is unaffected.

## Note

This only stops the *fabrication*. Reducing how often the fallback fires (e.g. carrying the
per-packet SNR/RSSI into `QueuedPacket` at reception so the publish path doesn't depend on the 1 s
`_last_raw_*` window) is a separate, optional robustness improvement.
