### PR TITLE
fix(rak3112): use DIO flash mode with OPI PSRAM to fix boot loop

### DIFF
--- a/variants/rak3112/platformio.ini
+++ b/variants/rak3112/platformio.ini
@@ -106,7 +106,11 @@ extra_scripts =
 board_ssl_cert_source = adafruit-full
 board_build.embed_files = src/certs/x509_crt_bundle.bin
 board_build.arduino.memory_type = qio_opi
-board_build.flash_mode = qio
+; OPI (octal) PSRAM shares the SPI0/1 bus data lines with flash; QIO flash mode
+; is unreliable in that config on ESP32-S3 (N16R8-class) and boot-loops. The
+; RAK3112 is 16MB quad flash + 8MB octal PSRAM, so use DIO flash mode (matches
+; RAKwireless/Meshtastic's own RAK3312 board definition for this module).
+board_build.flash_mode = dio
 board_build.psram_type = opi
 build_flags =
   ${rak3112.build_flags}
@@ -174,7 +178,11 @@ extra_scripts =
 board_ssl_cert_source = adafruit-full
 board_build.embed_files = src/certs/x509_crt_bundle.bin
 board_build.arduino.memory_type = qio_opi
-board_build.flash_mode = qio
+; OPI (octal) PSRAM shares the SPI0/1 bus data lines with flash; QIO flash mode
+; is unreliable in that config on ESP32-S3 (N16R8-class) and boot-loops. The
+; RAK3112 is 16MB quad flash + 8MB octal PSRAM, so use DIO flash mode (matches
+; RAKwireless/Meshtastic's own RAK3312 board definition for this module).
+board_build.flash_mode = dio
 board_build.psram_type = opi
 build_flags =
   ${rak3112.build_flags}


### PR DESCRIPTION
## Problem

Enabling PSRAM on the RAK3112 (added in cf1a8107) makes the board fail to boot / boot-loop.

## Root cause

The RAK3112 is an ESP32-S3 with **16MB quad flash + 8MB octal (OPI) PSRAM** (N16R8-class — confirmed against RAKwireless's datasheet and Meshtastic's `wiscore_rak3312` board definition, which targets this same module).

The PSRAM commit correctly set `memory_type = qio_opi` and `psram_type = opi`, but also pinned **`flash_mode = qio`**. On the ESP32-S3, octal PSRAM shares the SPI0/1 bus data lines, and QIO flash mode is unreliable once OPI PSRAM is active — the well-documented N16R8 boot-loop. This is why the non-PSRAM RAK3112 envs boot fine on the devkit-default QIO (no OPI PSRAM active), but the observer envs don't.

The board header (`RAK3112Board.h`) is only pin definitions and never touches PSRAM, so "matches upstream" was accurate but unrelated to the failure.

## Fix

Switch `flash_mode` from `qio` to `dio` for both PSRAM-enabled envs (`RAK_3112_repeater_observer_mqtt`, `RAK_3112_room_server_observer_mqtt`). This matches Meshtastic's RAK3312 board definition (`memory_type qio_opi` + `flash_mode dio` + `BOARD_HAS_PSRAM`). `memory_type` and `psram_type` were already correct and are unchanged.

## Verification

- `pio project config` parses cleanly and resolves `flash_mode = dio` for the observer envs.
- On-hardware boot test still needed to confirm the fix ends the boot loop.