### PR TITLE
Phase 5: cooperative MQTT shutdown + OTA teardown barrier

### DIFF
--- a/ALERTS.md
+++ b/ALERTS.md
@@ -31,6 +31,16 @@ Alert floods ride the **repeater's default scope** by default (the same Transpor
 
 A "recovered" message is sent once when the underlying connection comes back. After firing, a fault is rate-limited by `alert.interval` (default 60 minutes) before it can re-fire - this prevents flapping links from spamming the channel.
 
+## OTA milestone alerts
+
+Key `ota update` milestones are also broadcast on the alert channel (in addition to the Serial log), so an operator who triggered the update via remote management still gets feedback: the real OTA work runs ~2.5 s after the command and reboots on success, both **outside** the command's reply window.
+
+- **Start** - `OTA update starting`, sent when the update is confirmed and scheduled (during the reply window, so it transmits before the flash blocks the loop).
+- **Fail/abort** - `OTA aborted: MQTT stop unclean, bridge resumed` (the teardown barrier withheld flashing) or `OTA aborted: <reason>` (preflight/download error). The bridge is resumed either way.
+- **Success** has no dedicated message: a successful flash reboots into the new image, so the node reappearing on the new version is the success signal.
+
+These share the alert channel, scope (`alert.region`), and the `alert` master switch with fault alerts - if `alert` is `off` or no channel is configured, OTA milestones are silent. Unlike fault alerts they are **not** rate-limited (OTA is operator-initiated and rare), and they are limited to these start/fail milestones - routine MQTT slot connect/disconnect never triggers an OTA alert.
+
 ## Defaults
 
 | Setting | Default | Notes |

--- a/MQTT_OWNERSHIP.md
+++ b/MQTT_OWNERSHIP.md
@@ -7,11 +7,14 @@ for each. It is paired with the fork-owned lifecycle test seam
 (`src/helpers/MQTTLifecycle.h`, `test/test_mqtt_lifecycle/`).
 
 **Status:** ownership model documented and the lifecycle/teardown test seam
-landed. The production rewiring it describes (publishing a plain-data snapshot,
-replacing the `volatile` handshakes, cooperative shutdown) is **deferred to
-Phase 5** — this document is the plan Phase 5 executes, not a description of
-current behavior. Line references are against the tree at the time of writing
-and should be re-verified before editing.
+landed (Phase 4). **Phase 5 (branch `phase5/cooperative-mqtt-shutdown`) has now
+implemented the cooperative shutdown and the OTA barrier — hazard §4 below.**
+Still **deferred** (carried to Phase 5b / Phase 6): publishing a plain-data
+snapshot and repointing the §1/§2 consumers, and replacing the §3 `volatile`
+handshakes with a command channel. This document is the plan; §1–§3 still
+describe current behavior, while §4 is now resolved (see its note). Line
+references are against the tree at the time of writing and should be re-verified
+before editing.
 
 ## Execution contexts
 
@@ -98,15 +101,31 @@ clears/processes and writes a "done" flag last, Core 1 spins:
 The two blocking waiters (`requestForcedNtpSync` `:3298`, `ntpDiag` `:3344`) spin
 on Core 1 while `end()` could tear down the singleton/task concurrently.
 
-### 4. Abrupt teardown, no start guard
+### 4. Abrupt teardown, no start guard — RESOLVED in Phase 5
 
-- `end()` uses `vTaskDelete(_mqtt_task_handle)` (`MQTTBridge.cpp:862`) — the task
-  is killed wherever it is (possibly mid-`_slots[]` mutation, or inside
-  mbedTLS); slot/client cleanup then runs *after* deletion on the caller's
-  context (`:902-905`). This is the OTA teardown heap-panic path.
-- `begin()` (`:626`) has **no double-call guard** — a second `begin()` re-runs
-  allocation and `xTaskCreatePinnedToCore`, leaking the prior queue/task.
-- Lifecycle state is a single `_initialized` bool; there is no state enum.
+Original hazard (retained for context): `end()` used
+`vTaskDelete(_mqtt_task_handle)` to kill the task wherever it was (possibly
+mid-`_slots[]` mutation or inside mbedTLS), then ran slot/client cleanup *after*
+deletion on the caller's context — the OTA teardown heap-panic path. `begin()`
+had no double-call guard, and lifecycle state was a single `_initialized` bool.
+
+**Phase 5 resolution** (branch `phase5/cooperative-mqtt-shutdown`):
+
+- `end()` now requests a cooperative stop through `MQTTLifecycle::Coordinator`.
+  The MQTT task (Core 0) tears down its own clients where the mbedTLS contexts
+  live, acknowledges via `_stop_acked`, and self-terminates; `end()` waits for
+  the ack before freeing the queue/buffers. The blind `vTaskDelete` survives
+  only as the bounded-timeout fallback, which sets a dirty latch that withholds
+  OTA flashing (`canFlashAfterStop()`).
+- `begin()` has an idempotent double-call guard and drives the Coordinator to
+  `Running`; the lifecycle state now lives in the tested state machine, not a
+  bare bool.
+- The OTA barrier gates `simple_repeater`'s deferred flash on a clean stop.
+
+Not hardware-validated yet (Phase 7); `MQTT_STOP_TIMEOUT_MS` is a Phase-0
+placeholder. Note the residual §1/§2 instance-pointer reads remain deferred, so
+consumers can still (as before) touch a torn-down bridge — that is unchanged by
+Phase 5 and tracked above.
 
 ## Target primitives (Phase 5)
 

--- a/STABILITY_TESTABILITY_HANDOFF.md
+++ b/STABILITY_TESTABILITY_HANDOFF.md
@@ -26,7 +26,7 @@ index.
 | 1 | PR CI smoke builds + ArduinoJson pin enforcement | Done (build-size gate and ASan/UBSan still pending) |
 | 2 | PSRAM restart resource symmetry | Done |
 | 3 | MQTT preference migration fixtures | Done (filesystem adapter still lives in `CommonCLI`) |
-| 0 | Pre-change lifecycle characterization | Hardware run 2026-07-19 (see "Hardware Characterization Results"): teardown timing measured on V3+V4. **Finding: `MQTT_STOP_TIMEOUT_MS=8000` is too small — trips dirty/OTA-withheld on healthy multi-slot nodes; fix pending review** |
+| 0 | Pre-change lifecycle characterization | Hardware run 2026-07-19 (see "Hardware Characterization Results"): teardown timing measured on V3+V4. Finding: flat `MQTT_STOP_TIMEOUT_MS=8000` too small → **FIXED** with slot-scaled timeout (`5s + 8s×slots`), hardware-verified (2-slot stop now clean) |
 | 4 | Ownership and teardown test seams | Seams + ownership doc + teardown tests done; production rewiring deferred to Phase 5 |
 | 5 | Cooperative MQTT shutdown | Minimal cooperative `end()` + `begin()` guard + OTA barrier implemented on branch `phase5/cooperative-mqtt-shutdown` (native green, firmware smoke build green); NOT hardware-validated. Volatile-handshake replacement + snapshot-consumer repointing deferred |
 | — | OTA teardown barrier | Implemented — flash gated on a clean MQTT stop in `simple_repeater`; not hardware-validated |
@@ -89,18 +89,29 @@ permanently withheld** with the current timeout — the barrier misclassifies
 healthy stops as dirty. This inverts the barrier's intent and must be fixed
 before Phase 5 ships.
 
-**Recommendation (needs review — a Phase 5 code change, not applied here):**
+**FIX APPLIED (slot-count-aware timeout) — verified on hardware.**
 
-- Raise `MQTT_STOP_TIMEOUT_MS` so healthy multi-slot teardowns complete cleanly.
-  Either a single constant sized for the 5-slot PSRAM worst case (**≥ ~35 s**,
-  with headroom), or — preferred — **make it slot-count-aware**, e.g.
-  `base 4 s + 6 s × active_slots` (2→16 s, 3→22 s, 5→34 s).
-- A larger fixed timeout lengthens the loop-task stall on every stop
-  (`ota update`, reconfigure-restart, `set bridge.enabled off`); the slot-aware
-  form avoids penalizing 1-slot nodes.
-- Alternative/complementary (deeper Phase 5 work): shorten the per-slot
-  `esp_mqtt_client_destroy()` wait so total teardown drops under a smaller
-  timeout. Out of scope for this characterization; flagged for decision.
+The flat `MQTT_STOP_TIMEOUT_MS = 8000` is replaced by a slot-scaled budget
+computed per stop in `MQTTBridge::end()`:
+
+```
+timeout = MQTT_STOP_TIMEOUT_BASE_MS (5000) + MQTT_STOP_TIMEOUT_PER_SLOT_MS (8000) × enabled_slots
+```
+
+→ 1 slot 13 s, 2 slots 21 s, 3 slots 29 s, 5 slots 45 s — ~1.5–2× headroom over
+the measured ~5–6 s/slot teardown. `end()` counts enabled slots and calls
+`Coordinator::setStopTimeoutMs()` before `requestStop()`. Headroom is nearly free
+because `end()` returns as soon as the task acks (`_stop_acked` is checked before
+the timeout ticks), so a larger bound does not slow a healthy stop — it only
+lengthens the wait before force-killing a genuinely wedged task. (Files:
+`MQTTBridge.cpp` constants + `end()`; `MQTTLifecycle.h` `setStopTimeoutMs()`.)
+
+**Hardware verification (V3, this fix):** the same 2-slot config that force-timed-
+out at 8 s pre-fix now logs `MQTT stop: 2 enabled slot(s), timeout 21000 ms` and
+acks in ~11.7 s → **`MQTT Bridge stopped (clean)`** (OTA no longer withheld).
+Native suite + both firmware builds green. Complementary future option (not done):
+shorten the per-slot `esp_mqtt_client_destroy()` wait to reduce absolute teardown
+time.
 
 ### Phase 0 — cooperative lifecycle (V3, non-PSRAM, this branch)
 
@@ -555,16 +566,16 @@ publishing a plain-data status snapshot to repoint the §1/§2 consumers in
 that can still touch a torn-down bridge). Those are not required to fix the OTA
 panic and would enlarge the merge-sensitive diff.
 
-**Phase 0 dependency — CHARACTERIZED 2026-07-19, ACTION REQUIRED:**
-`MQTT_STOP_TIMEOUT_MS` = 8 s placeholder is **too small**. Measured per-wss-slot
-teardown is ~5–6 s sequential, so a healthy stop needs ~11–12 s at 2 slots
-(non-PSRAM max) and ~16 s at 3 slots / ~27–30 s at 5 slots (PSRAM). At 8 s these
-healthy stops trip the dirty/timeout fallback and the OTA barrier withholds
-flashing — i.e. multi-slot nodes could never `ota update`. Raise it (single
-constant ≥ ~35 s for the 5-slot worst case, or preferably slot-count-aware,
-e.g. `4 s + 6 s × active_slots`) before this ships. See "Hardware
-Characterization Results (Phase 0 & Phase 7)". It is a single named constant so
-the change is trivial.
+**Phase 0 dependency — CHARACTERIZED + FIXED 2026-07-19:** the flat
+`MQTT_STOP_TIMEOUT_MS` = 8 s placeholder was **too small** (measured per-wss-slot
+teardown ~5–6 s sequential → ~11–12 s at 2 slots, ~16 s at 3, ~27–30 s at 5; at
+8 s healthy multi-slot stops tripped the dirty fallback and the OTA barrier
+withheld flashing). Replaced with a **slot-scaled timeout** set per stop in
+`end()`: `5 s + 8 s × enabled_slots` (`MQTT_STOP_TIMEOUT_BASE_MS` /
+`MQTT_STOP_TIMEOUT_PER_SLOT_MS`, applied via `Coordinator::setStopTimeoutMs()`).
+Hardware-verified: a 2-slot stop that force-timed-out pre-fix now acks clean in
+~11.7 s within the 21 s budget. See "Hardware Characterization Results (Phase 0 &
+Phase 7)".
 
 The original plan of record follows. Replace direct task deletion with an
 explicit lifecycle such as:

--- a/STABILITY_TESTABILITY_HANDOFF.md
+++ b/STABILITY_TESTABILITY_HANDOFF.md
@@ -106,12 +106,12 @@ the timeout ticks), so a larger bound does not slow a healthy stop — it only
 lengthens the wait before force-killing a genuinely wedged task. (Files:
 `MQTTBridge.cpp` constants + `end()`; `MQTTLifecycle.h` `setStopTimeoutMs()`.)
 
-**Hardware verification (V3, this fix):** the same 2-slot config that force-timed-
-out at 8 s pre-fix now logs `MQTT stop: 2 enabled slot(s), timeout 21000 ms` and
-acks in ~11.7 s → **`MQTT Bridge stopped (clean)`** (OTA no longer withheld).
-Native suite + both firmware builds green. Complementary future option (not done):
-shorten the per-slot `esp_mqtt_client_destroy()` wait to reduce absolute teardown
-time.
+**Hardware verification (both memory paths):** the same configs that force-timed-
+out at 8 s pre-fix now ack cleanly — V3 non-PSRAM 2-slot logs `timeout 21000 ms`
+and acks in ~11.7 s; V4 PSRAM 3-slot logs `timeout 29000 ms` and acks in ~16.4 s
+→ **`MQTT Bridge stopped (clean)`** (OTA no longer withheld). Native suite + both
+firmware builds green. Complementary future option (not done): shorten the
+per-slot `esp_mqtt_client_destroy()` wait to reduce absolute teardown time.
 
 ### Phase 0 — cooperative lifecycle (V3, non-PSRAM, this branch)
 

--- a/STABILITY_TESTABILITY_HANDOFF.md
+++ b/STABILITY_TESTABILITY_HANDOFF.md
@@ -26,10 +26,10 @@ index.
 | 1 | PR CI smoke builds + ArduinoJson pin enforcement | Done (build-size gate and ASan/UBSan still pending) |
 | 2 | PSRAM restart resource symmetry | Done |
 | 3 | MQTT preference migration fixtures | Done (filesystem adapter still lives in `CommonCLI`) |
-| 0 | Pre-change lifecycle characterization | Not started — deterministic behavior encoded in Phase 4; hardware items pending |
+| 0 | Pre-change lifecycle characterization | Deterministic behavior encoded in Phase 4/5; hardware items pending (stop-timeout value is a placeholder) |
 | 4 | Ownership and teardown test seams | Seams + ownership doc + teardown tests done; production rewiring deferred to Phase 5 |
-| 5 | Cooperative MQTT shutdown | Not started (fixes the OTA teardown panic) |
-| — | OTA teardown barrier | Not started — release-critical |
+| 5 | Cooperative MQTT shutdown | Minimal cooperative `end()` + `begin()` guard + OTA barrier implemented on branch `phase5/cooperative-mqtt-shutdown` (native green, firmware smoke build green); NOT hardware-validated. Volatile-handshake replacement + snapshot-consumer repointing deferred |
+| — | OTA teardown barrier | Implemented — flash gated on a clean MQTT stop in `simple_repeater`; not hardware-validated |
 | 6 | Request/queue/connection/publication integration tests | Not started |
 | 7 | Uptime, memory, and fault-injection gates | Not started |
 
@@ -387,15 +387,44 @@ to bridge teardown, OTA sequencing, MQTT client lifetime, or task ownership.
 
 ### Phase 5: Implement cooperative MQTT shutdown
 
-**Status: Not started.** Verified premise: `end()` stops the MQTT task with a
-direct `vTaskDelete` mid-operation and no handshake, and lifecycle state is a
-single `_initialized` bool (no state enum). Note also that `begin()` is not
-currently guarded against a double-call — it re-creates the queue and task,
-leaking the prior ones — so fold that guard into the idempotent-start requirement
-below rather than leaving it to caller discipline.
+**Status: Minimal cooperative shutdown implemented on branch
+`phase5/cooperative-mqtt-shutdown` (scope: "the smallest change that fixes the
+OTA teardown panic as one reviewable unit"). Native suite green; the non-PSRAM
+observer firmware smoke build compiles. NOT yet hardware-validated — that is the
+Phase 7 gate — and the stop timeout is a Phase-0 placeholder (see below).**
 
-With Phase 0 behavior recorded and Phase 4 tests in place, replace direct task
-deletion with an explicit lifecycle such as:
+What landed (wiring the Phase 4 `MQTTLifecycle` state machine into the bridge):
+
+- `MQTTBridge` owns a `MQTTLifecycle::Coordinator` driven **only** by the loop
+  task (Core 1) from `begin()`/`end()`. A nested `LifecycleOps` binds the pure,
+  host-tested `Ops` spec to FreeRTOS/PsychicMqttClient.
+- `end()` no longer blind-`vTaskDelete`s. It requests a cooperative stop; the
+  MQTT task (Core 0) sees a new `volatile _stop_requested`, tears down its own
+  clients **on Core 0 where the mbedTLS contexts live**, sets `_stop_acked`
+  last, and self-terminates. `end()` waits (bounded) for the ack, then frees the
+  queue/buffers. This removes the "kill the task mid-mbedTLS, then free client
+  buffers on a corrupted heap" teardown path.
+- Bounded stop timeout → reviewed fallback: on timeout the task is force-killed
+  and torn down on Core 1 (the old behavior), but a **dirty latch** is set so
+  `canFlashAfterStop()` is false and OTA flashing is withheld.
+- `begin()` has a double-call guard and syncs the Coordinator to `Running`.
+- OTA teardown barrier: `simple_repeater`'s deferred-OTA fire site aborts and
+  resumes the bridge unless the preceding `end()` reported a clean stop.
+
+Deferred (kept out of this reviewable unit; carried to a Phase 5b / Phase 6):
+replacing the `volatile` NTP/reconfigure handshakes with a command channel, and
+publishing a plain-data status snapshot to repoint the §1/§2 consumers in
+`MQTT_OWNERSHIP.md` (the `AlertReporter`/`buildStatsJson` instance-pointer reads
+that can still touch a torn-down bridge). Those are not required to fix the OTA
+panic and would enlarge the merge-sensitive diff.
+
+**Phase 0 dependency still open:** `MQTT_STOP_TIMEOUT_MS` is a conservative 8 s
+placeholder. It must be characterized against real mbedTLS teardown over `wss`
+with a down broker (Phase 0) before this ships; it is a single named constant so
+that change is trivial.
+
+The original plan of record follows. Replace direct task deletion with an
+explicit lifecycle such as:
 
 `Stopped -> Starting -> Running -> StopRequested -> Stopping -> Stopped`
 

--- a/STABILITY_TESTABILITY_HANDOFF.md
+++ b/STABILITY_TESTABILITY_HANDOFF.md
@@ -26,16 +26,153 @@ index.
 | 1 | PR CI smoke builds + ArduinoJson pin enforcement | Done (build-size gate and ASan/UBSan still pending) |
 | 2 | PSRAM restart resource symmetry | Done |
 | 3 | MQTT preference migration fixtures | Done (filesystem adapter still lives in `CommonCLI`) |
-| 0 | Pre-change lifecycle characterization | Deterministic behavior encoded in Phase 4/5; hardware items pending (stop-timeout value is a placeholder) |
+| 0 | Pre-change lifecycle characterization | Hardware run 2026-07-19 (see "Hardware Characterization Results"): teardown timing measured on V3+V4. **Finding: `MQTT_STOP_TIMEOUT_MS=8000` is too small — trips dirty/OTA-withheld on healthy multi-slot nodes; fix pending review** |
 | 4 | Ownership and teardown test seams | Seams + ownership doc + teardown tests done; production rewiring deferred to Phase 5 |
 | 5 | Cooperative MQTT shutdown | Minimal cooperative `end()` + `begin()` guard + OTA barrier implemented on branch `phase5/cooperative-mqtt-shutdown` (native green, firmware smoke build green); NOT hardware-validated. Volatile-handshake replacement + snapshot-consumer repointing deferred |
 | — | OTA teardown barrier | Implemented — flash gated on a clean MQTT stop in `simple_repeater`; not hardware-validated |
 | 6 | Request/queue/connection/publication integration tests | Not started |
-| 7 | Uptime, memory, and fault-injection gates | Not started |
+| 7 | Uptime, memory, and fault-injection gates | Representative HW matrix run 2026-07-19: V3 non-PSRAM + V4 PSRAM done (no leak/crash; forced-path OTA-withhold + ~15–27 s loop stall observed). Multi-day soak + stack-HWM build pending |
 
 Forward plan, in execution order: **Phase 0 → Phase 4 → Phase 5 (with the OTA
 teardown barrier) → Phase 6 → Phase 7.** Do not reopen a "Done" phase without a
 deliberate reason (see "Change-Control Discipline").
+
+## Hardware Characterization Results (Phase 0 & Phase 7) — 2026-07-19
+
+Hardware run of the outstanding Phase 0 (pre-change/cooperative teardown timing)
+and Phase 7 (uptime/memory/fault-injection) items against two live observer
+nodes. **Not yet committed as a plan change — this section records measured
+results and a release-gating recommendation for review.**
+
+### Setup
+
+- **V3** — Heltec WiFi LoRa 32 **V3**, non-PSRAM (max 2 active slots), env
+  `Heltec_v3_repeater_observer_mqtt`, 1 configured slot (`meshmapper`, wss).
+- **V4** — Heltec WiFi LoRa 32 **V4**, **2 MB PSRAM** (max 5 active slots), env
+  `heltec_v4_repeater_observer_mqtt`, 3 configured slots (`analyzer-us`,
+  `cascadiamesh`, `waev`, all wss). mbedTLS + JSON/raw buffers allocate in PSRAM.
+- Both flashed with this branch (`phase5/cooperative-mqtt-shutdown`) via
+  `pio run -t upload` (app-slot flash only; `nvs`+`spiffs` preserved, no erase).
+  Note: `FIRMWARE_VERSION`/`FIRMWARE_BUILD_DATE` are hardcoded in `MyMesh.h` and
+  were not bumped, so `ver` reads "v1.16.0 (6 Jun 2026)" on both old and new
+  builds — confirm the flash by behavior (the `(clean)` / cooperative-stop log
+  lines), not by `ver`.
+- Driven over the serial CLI (`set bridge.enabled off/on` = `end()`/`begin()`;
+  `set mqttN.*` = slot reconfigure; `get mqtt.stats` = `Free`/`Max`(largest
+  block)/queue/outbox/per-slot counters). Host-side timestamped log parsing.
+
+### PRIMARY FINDING — `MQTT_STOP_TIMEOUT_MS = 8000` is too small (release-gating)
+
+Per-wss-slot teardown costs **~5–6 s**, applied **sequentially**
+(`destroySlotClients()`: `disconnect()` → 50 ms → `esp_mqtt_client_destroy()`;
+the ~5 s is the esp-mqtt task/network close, not the 50 ms settle). This is
+unchanged from the pre-change path (same teardown code), so the cooperative
+`end()` ack time scales with the number of connected slots:
+
+| Config | Slots | Measured teardown | vs 8 s timeout | Result |
+|--------|-------|-------------------|----------------|--------|
+| V3 non-PSRAM | 1 wss | ack ~5.3–6.2 s (avg 5.8) | under | **clean** ✅ |
+| V3 non-PSRAM (design max) | 2 wss | ~11–12 s (cut off at 8 s) | **over** | **forced/dirty → OTA withheld** ❌ |
+| V4 PSRAM (normal config) | 3 wss | ~16 s (cut off at 8 s; per-slot disc @2.2/7.8/10.6 s) | **over** | **forced/dirty → OTA withheld** ❌ |
+| V4 PSRAM (design max) | 5 wss | ~27–30 s projected | **far over** | forced/dirty → OTA withheld ❌ |
+
+Pre-change (v1.16.0) reference teardown (same nodes, blocking `end()`): 1 slot
+~6.1 s (V3), 3 slots ~16.4 s (V4) — consistent with the above.
+
+**Consequence:** at the non-PSRAM board's *designed maximum* of 2 wss slots, and
+on a *normal healthy* 3-slot PSRAM node, an ordinary cooperative shutdown exceeds
+8 s → the coordinator fires `StopTimedOut` → sets the dirty latch → force-kills
+the MQTT task (the exact mbedTLS-mid-teardown path Phase 5 exists to avoid) and
+`canFlashAfterStop()` returns false. Because the OTA barrier only flashes after a
+**clean** stop, this means **any multi-slot device would have `ota update`
+permanently withheld** with the current timeout — the barrier misclassifies
+healthy stops as dirty. This inverts the barrier's intent and must be fixed
+before Phase 5 ships.
+
+**Recommendation (needs review — a Phase 5 code change, not applied here):**
+
+- Raise `MQTT_STOP_TIMEOUT_MS` so healthy multi-slot teardowns complete cleanly.
+  Either a single constant sized for the 5-slot PSRAM worst case (**≥ ~35 s**,
+  with headroom), or — preferred — **make it slot-count-aware**, e.g.
+  `base 4 s + 6 s × active_slots` (2→16 s, 3→22 s, 5→34 s).
+- A larger fixed timeout lengthens the loop-task stall on every stop
+  (`ota update`, reconfigure-restart, `set bridge.enabled off`); the slot-aware
+  form avoids penalizing 1-slot nodes.
+- Alternative/complementary (deeper Phase 5 work): shorten the per-slot
+  `esp_mqtt_client_destroy()` wait so total teardown drops under a smaller
+  timeout. Out of scope for this characterization; flagged for decision.
+
+### Phase 0 — cooperative lifecycle (V3, non-PSRAM, this branch)
+
+- 6× and 10× `begin→connect→end→restart` cycles: **all clean**, ack 5.3–6.2 s,
+  end() loop-task block ≤6.9 s, restart→connect ~5.4 s.
+- **No leak across full stop/start cycles:** free heap flat (~137–142 k, varies
+  only with the meshmapper outbox), largest free block stable (~115–129 k). This
+  satisfies Phase 5's "no downward heap/largest-block trend across start/stop
+  cycles" acceptance criterion on the non-PSRAM path.
+
+### OTA teardown barrier
+
+- Barrier **input** validated on hardware in both states: clean stops →
+  `canFlashAfterStop()` true; forced/timeout stops log `OTA blocked` /
+  `OTA flashing withheld` (= `canFlashAfterStop()` false). Confirmed
+  `mayBeginFlash() == (Stopped && !_stop_timed_out)`; a fresh start clears the
+  latch; a dirty stop still permits restart.
+- Barrier **action** (`simple_repeater` aborts+resumes vs. proceeds) is a
+  one-line gate on that latch (`MyMesh.cpp` deferred-OTA site) — validated by
+  code + the Phase 4 host lifecycle tests.
+- **Not exercised end-to-end on hardware:** the live `ota update` deferred-flash
+  path. A plain `pio run` build reports `ERR: OTA not configured (build via
+  build.sh)`, so `otaFromManifest` bails before scheduling; driving it needs a
+  `build.sh` firmware + a controlled manifest, and was not improvised on working
+  fleet nodes (risk of flashing a real fleet build). Recommend a dedicated
+  bench run for this.
+
+### Phase 7 — fault-injection matrix (V3 non-PSRAM; representative, not the soak)
+
+Matrix: 10 clean stop/start + 5 forced 2-slot teardowns + 8 slot-reconfigure +
+4 down-broker (`wss://192.0.2.1`) flaps. Time series of free/largest-block/
+queue/outbox recorded per step; reboot/crash detection on.
+
+- **No crash across the entire matrix** (incl. 5 repeated force-kill fallbacks) —
+  the reviewed dirty-stop fallback is robust on non-PSRAM.
+- **Forced teardown reproducible:** every 2-slot stop timed out (acks 7.4–8.2 s),
+  reinforcing the primary finding.
+- **Bounded fragmentation, fully recoverable:** slot-level reconfigure/flap
+  churn (which keeps a disabled slot's persistent client until a *full* bridge
+  restart) dropped the largest free block from ~125 k to ~72 k and held ~17 k of
+  free heap, but it **plateaued** (stable across 12 churn iterations, not an
+  unbounded leak) and a reboot fully restored ~141 k free / ~125 k largest block.
+  This is pre-existing bridge behavior (TLS-context lifecycle), not a Phase 5
+  regression.
+
+### Phase 7 — forced-teardown stress (V4 PSRAM, 3 wss slots, this branch)
+
+8× `end()`/`begin()` cycles at the node's normal 3-slot config (every stop
+exceeds 8 s → forced/dirty):
+
+- **All 8 forced, no leak, no crash.** Largest free block **rock-stable at
+  139 252 across all 8 cycles** (mbedTLS is PSRAM-allocated, so internal-heap
+  fragmentation is absent on the PSRAM path); free internal heap flat. The
+  force-kill fallback is robust on PSRAM too.
+- **Loop-task stall is severe on the forced path:** `end()` blocked the loop
+  task **~15–27 s** per stop, because the forced path waits the full 8 s timeout
+  and *then* runs a complete redundant teardown on Core 1 (≈ 8 s + ~16 s). During
+  that window the repeater's mesh/CLI/radio servicing is stalled. Sizing the
+  timeout so the cooperative (Core-0) teardown completes cleanly removes both the
+  OTA-withhold and this double-teardown stall.
+- Both nodes left restored to their original config, bridge on, heap healthy.
+
+### Limitations / not covered
+
+- Task stack high-water mark and explicit task/client counts are not exposed by
+  the CLI; a dedicated `MQTT_MEMORY_DEBUG` build is needed for those (heap
+  stability was used as a proxy leak signal, and it held).
+- The 72 h / 7-day soaks were not run (bounded representative cycles per agreed
+  scope); WiFi loss/recovery, TLS-handshake failure, queue saturation, JWT/NTP
+  failure, and `millis()`-rollover scenarios need external network control /
+  time injection and were not driven over serial.
+- Both devices left restored to their original slot config with the bridge on.
 
 ## Current Baseline
 
@@ -418,10 +555,16 @@ publishing a plain-data status snapshot to repoint the §1/§2 consumers in
 that can still touch a torn-down bridge). Those are not required to fix the OTA
 panic and would enlarge the merge-sensitive diff.
 
-**Phase 0 dependency still open:** `MQTT_STOP_TIMEOUT_MS` is a conservative 8 s
-placeholder. It must be characterized against real mbedTLS teardown over `wss`
-with a down broker (Phase 0) before this ships; it is a single named constant so
-that change is trivial.
+**Phase 0 dependency — CHARACTERIZED 2026-07-19, ACTION REQUIRED:**
+`MQTT_STOP_TIMEOUT_MS` = 8 s placeholder is **too small**. Measured per-wss-slot
+teardown is ~5–6 s sequential, so a healthy stop needs ~11–12 s at 2 slots
+(non-PSRAM max) and ~16 s at 3 slots / ~27–30 s at 5 slots (PSRAM). At 8 s these
+healthy stops trip the dirty/timeout fallback and the OTA barrier withholds
+flashing — i.e. multi-slot nodes could never `ota update`. Raise it (single
+constant ≥ ~35 s for the 5-slot worst case, or preferably slot-count-aware,
+e.g. `4 s + 6 s × active_slots`) before this ships. See "Hardware
+Characterization Results (Phase 0 & Phase 7)". It is a single named constant so
+the change is trivial.
 
 The original plan of record follows. Replace direct task deletion with an
 explicit lifecycle such as:

--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -1575,11 +1575,18 @@ void MyMesh::loop() {
     // resume the bridge instead of flashing under uncertain ownership.
     if (bridge && !bridge->canFlashAfterStop()) {
       Serial.println("OTA: aborted, MQTT stop did not complete cleanly - resuming bridge");
+      otaAlert("OTA aborted: MQTT stop unclean, bridge resumed");
       setBridgeState(true);
     } else if (!_cli.getBoard()->otaFromManifest(getFirmwareVer(), false, ota_reply)) {
       Serial.print("OTA: aborted, resuming bridge - "); Serial.println(ota_reply);
+      char ota_alert_msg[160];
+      snprintf(ota_alert_msg, sizeof(ota_alert_msg), "OTA aborted: %s", ota_reply);
+      otaAlert(ota_alert_msg);
       setBridgeState(true);
     }
+    // Success path: otaFromManifest() flashes and reboots into the new image
+    // (never returns), so there is no in-boot "success" alert — the START alert
+    // plus the node returning on the new version is the success signal.
   }
 #endif
 

--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -1569,7 +1569,14 @@ void MyMesh::loop() {
     Serial.println("OTA: starting update");
     setBridgeState(false);
     char ota_reply[160];
-    if (!_cli.getBoard()->otaFromManifest(getFirmwareVer(), false, ota_reply)) {
+    // OTA teardown barrier (Phase 5): only flash after a CLEAN MQTT shutdown.
+    // A timed-out/forced stop leaves mbedTLS/heap ownership uncertain — writing
+    // firmware then is the observed teardown heap-panic path — so abort and
+    // resume the bridge instead of flashing under uncertain ownership.
+    if (bridge && !bridge->canFlashAfterStop()) {
+      Serial.println("OTA: aborted, MQTT stop did not complete cleanly - resuming bridge");
+      setBridgeState(true);
+    } else if (!_cli.getBoard()->otaFromManifest(getFirmwareVer(), false, ota_reply)) {
       Serial.print("OTA: aborted, resuming bridge - "); Serial.println(ota_reply);
       setBridgeState(true);
     }

--- a/examples/simple_repeater/MyMesh.h
+++ b/examples/simple_repeater/MyMesh.h
@@ -344,12 +344,32 @@ public:
 #endif
   }
 
+#if defined(WITH_MQTT_BRIDGE)
+  // Broadcast a key OTA milestone (start/fail only) on the configured alert
+  // channel, in addition to the Serial log — so an operator who triggered
+  // `ota update` via remote management still gets feedback that lands well after
+  // the command's reply window. Respects the `alert on/off` master switch and
+  // rides the configured alert scope (sendChannel -> resolveAlertScope); a no-op
+  // when alerts are off or no channel is set. Deliberately NOT wired to routine
+  // slot connect/disconnect — those remain in AlertReporter's fault logic.
+  void otaAlert(const char* msg) {
+    auto* obs = _cli.getObserverPrefs();
+    if (obs && obs->alert_enabled) _alerter.sendText(msg);
+  }
+#endif
+
   // Schedule the pull-OTA flash to run from loop() in ~2.5 s, leaving time for the
   // "Beginning update..." CLI reply (CLI_REPLY_DELAY_MILLIS = 600 ms) to transmit
   // before the flash blocks the loop and reboots.
   bool beginDeferredOtaUpdate() override {
     _ota_update_at = millis() + 2500;
     if (_ota_update_at == 0) _ota_update_at = 1;  // 0 means "none"
+#if defined(WITH_MQTT_BRIDGE)
+    // Broadcast START now, while the loop still runs (the 2.5 s reply window):
+    // the deferred flash blocks the loop and, on success, reboots — so a start
+    // alert queued at fire time could never transmit. See otaAlert().
+    otaAlert("OTA update starting");
+#endif
     return true;
   }
 

--- a/src/helpers/CommonCLI_Observer.cpp
+++ b/src/helpers/CommonCLI_Observer.cpp
@@ -785,7 +785,7 @@ bool CommonCLI::handleObserverGetCmd(uint32_t sender_timestamp, const char* conf
       if (_mqtt_prefs.mqtt_slot_audience[slot][0] != '\0') {
         sprintf(reply, "> %s", _mqtt_prefs.mqtt_slot_audience[slot]);
       } else {
-        strcpy(reply, "> (not set — custom slots use username/password auth)");
+        strcpy(reply, "> (not set - custom slots use username/password auth)");
       }
     } else if (memcmp(subcmd, "diag", 4) == 0) {
       MQTTBridge::formatSlotDiagReply(reply, 160, slot);

--- a/src/helpers/MQTTLifecycle.h
+++ b/src/helpers/MQTTLifecycle.h
@@ -245,9 +245,12 @@ struct Ops {
 // timeout. Idempotent start/stop; safe restart after a completed stop.
 class Coordinator {
  public:
-  // Phase 0 TODO: stop_timeout_ms must be characterized against real mbedTLS
-  // teardown timing over wss with a down broker before Phase 5 ships. It is an
-  // injected parameter precisely so it is not a guessed constant here.
+  // stop_timeout_ms is the bound on how long a requested stop may run before the
+  // reviewed force-kill fallback fires. It is injected (not a constant here) and
+  // may be updated per stop via setStopTimeoutMs(): Phase 0 hardware
+  // characterization (2026-07-19) showed real mbedTLS/wss teardown scales with
+  // the number of connected slots (~5-6 s each, sequential), so the owner sizes
+  // it to the current slot count before each stop. See MQTTBridge::end().
   Coordinator(Ops& ops, uint32_t stop_timeout_ms)
       : _ops(ops), _stop_timeout_ms(stop_timeout_ms) {}
 
@@ -271,6 +274,12 @@ class Coordinator {
   bool mayBeginFlash() const {
     return _state == State::Stopped && !_stop_timed_out;
   }
+
+  // Update the stop-timeout bound. Call before requestStop() to size the window
+  // to the current slot count (see MQTTBridge::end()); the value is read by
+  // tick() against _stop_request_ms, which requestStop() arms afterwards.
+  void setStopTimeoutMs(uint32_t ms) { _stop_timeout_ms = ms; }
+  uint32_t stopTimeoutMs() const { return _stop_timeout_ms; }
 
   bool requestStart() { return dispatch(Event::StartRequested); }
   bool requestStop() { return dispatch(Event::StopRequested); }

--- a/src/helpers/bridges/MQTTBridge.cpp
+++ b/src/helpers/bridges/MQTTBridge.cpp
@@ -473,6 +473,15 @@ void MQTTBridge::formatSlotDiagReply(char* buf, size_t bufsize, int slot_index) 
   }
 }
 
+// Bounded cooperative-stop timeout for end() (see MQTTLifecycle::Coordinator).
+// Phase 0 TODO: characterize on hardware — mbedTLS teardown over wss with a
+// DOWN broker — before this ships. The placeholder is chosen conservatively:
+// long enough for a real cooperative client teardown (per-slot disconnect + the
+// existing 50 ms settle delays across RUNTIME_MQTT_SLOTS), short enough to bound
+// the loop-task stall and the OTA/restart wait. A stop that exceeds this is
+// treated as dirty: the task is force-killed and OTA flashing is withheld.
+static const uint32_t MQTT_STOP_TIMEOUT_MS = 8000;
+
 // ---------------------------------------------------------------------------
 // Constructor
 // ---------------------------------------------------------------------------
@@ -514,6 +523,9 @@ MQTTBridge::MQTTBridge(NodePrefs *prefs, MQTTPrefs *obs, mesh::PacketManager *mg
 #else
       , _queue_head(0), _queue_tail(0)
 #endif
+      // Cooperative lifecycle: _lifecycle_ops must be constructed before
+      // _lifecycle (declaration order guarantees this) so the reference binds.
+      , _lifecycle_ops(this), _lifecycle(_lifecycle_ops, MQTT_STOP_TIMEOUT_MS)
 {
   // Initialize default values
   strncpy(_origin, "MeshCore-Repeater", sizeof(_origin) - 1);
@@ -625,6 +637,14 @@ void MQTTBridge::releaseRuntimeBuffers() {
 // ---------------------------------------------------------------------------
 void MQTTBridge::begin() {
   MQTT_DEBUG_PRINTLN("Initializing MQTT Bridge...");
+
+  // Idempotent start (Phase 5): a second begin() on an already-running bridge
+  // would re-run allocation and re-create the task, leaking the previous
+  // queue/task. Guard here instead of relying on caller discipline.
+  if (_initialized) {
+    MQTT_DEBUG_PRINTLN("MQTT Bridge already running — begin() ignored");
+    return;
+  }
 
   // PSRAM diagnostic - helps debug memory fragmentation on boards with external RAM
   #ifdef BOARD_HAS_PSRAM
@@ -805,6 +825,11 @@ void MQTTBridge::begin() {
   // causes resets on some boards (e.g. Heltec V4) when the task runs from PSRAM stack.
   _mqtt_task_stack = nullptr;
   _mqtt_task_handle = nullptr;
+  // Clear the cooperative-stop handshake before the new task starts reading it.
+  // deliverStop() leaves _stop_requested latched true after a stop cycle, so a
+  // restart must reset it or the fresh task would self-terminate immediately.
+  _stop_requested = false;
+  _stop_acked = false;
   BaseType_t create_result = xTaskCreatePinnedToCore(
     mqttTask,
     "MQTTBridge",
@@ -845,6 +870,14 @@ void MQTTBridge::begin() {
   // instead of churning ~40 KB of internal heap per cycle.
   initSlotClients();
 
+  // Sync the lifecycle Coordinator to Running now that all resources exist and
+  // the task is created. Driven only on the success path: the failure rollbacks
+  // above already free what they acquired and leave the bridge Stopped, so we
+  // must not also fire the state machine's release effect there (double free).
+  // A fresh start also clears any dirty-stop latch (re-enabling OTA flashing).
+  _lifecycle.requestStart();    // Stopped -> Starting (startTask() is a no-op here)
+  _lifecycle.onTaskStarted();   // Starting -> Running
+
   _initialized = true;
   s_mqtt_bridge_instance = this;
   MQTT_DEBUG_PRINTLN("MQTT Bridge initialized");
@@ -855,65 +888,140 @@ void MQTTBridge::begin() {
 // ---------------------------------------------------------------------------
 void MQTTBridge::end() {
   MQTT_DEBUG_PRINTLN("Stopping MQTT Bridge...");
+
+  // Idempotent stop: nothing to tear down if we never started (or already stopped).
+  if (!_initialized) {
+    MQTT_DEBUG_PRINTLN("MQTT Bridge already stopped — end() ignored");
+    return;
+  }
+
+  // Stop new diagnostic reads through the singleton before teardown begins.
   s_mqtt_bridge_instance = nullptr;
 
-  #ifdef ESP_PLATFORM
-  // Delete FreeRTOS task first (it will clean up WiFi/MQTT connections)
-  if (_mqtt_task_handle != nullptr) {
-    vTaskDelete(_mqtt_task_handle);
-    _mqtt_task_handle = nullptr;
-  }
-  // Free PSRAM task stack
-  psram_free(_mqtt_task_stack);
-  _mqtt_task_stack = nullptr;
+  // Cooperative shutdown (Phase 5). Request the stop, then let the lifecycle
+  // Coordinator drive it. On ESP32 the MQTT task (Core 0) tears down its own
+  // clients where the mbedTLS contexts live and acknowledges via _stop_acked;
+  // the queue/buffer release happens inside LifecycleOps::releaseResources()
+  // once the Coordinator reaches Stopped (clean ack OR the reviewed timeout
+  // fallback). This replaces the former blind vTaskDelete that could kill the
+  // task mid-mbedTLS and then free client buffers on a corrupted heap.
+  _lifecycle.requestStop();  // Running -> StopRequested; deliverStop() sets _stop_requested
 
-  // Clean up queued packets from FreeRTOS queue
-  // Packets are value-copied in the queue, so no external pointers to clean up.
-  if (_packet_queue_handle != nullptr) {
-    QueuedPacket queued;
-    while (xQueueReceive(_packet_queue_handle, &queued, 0) == pdTRUE) {
-      _queue_count--;
+#ifdef ESP_PLATFORM
+  // Wait (bounded) for the task to acknowledge. tick() synthesizes the timeout
+  // fallback if the task never acks. Checking the ack first each iteration means
+  // a stop that completes right as the timeout expires is still treated as clean.
+  while (_lifecycle.isStopInProgress()) {
+    if (_stop_acked) {
+      _lifecycle.onTaskStopped();   // StopRequested -> Stopped (clean): releaseResources()
+      break;
     }
-    vQueueDelete(_packet_queue_handle);
-    _packet_queue_handle = nullptr;
+    _lifecycle.tick();              // may fire StopTimedOut -> Stopped (dirty): releaseResources()
+    if (!_lifecycle.isStopInProgress()) break;
+    vTaskDelay(pdMS_TO_TICKS(20));
   }
-  #if defined(BOARD_HAS_PSRAM)
-  psram_free(_packet_queue_storage);
-  #endif
-  _packet_queue_storage = nullptr;
+#else
+  // Non-ESP32: the bridge runs cooperatively in loop(); there is no separate
+  // task to signal. Drive straight to a clean Stopped and let releaseResources()
+  // perform the (unchanged) synchronous teardown.
+  _stop_acked = true;
+  _lifecycle.onTaskStopped();
+#endif
 
-  #else
-  // Clean up queued packet references
-  // Packets are value-copied in the queue, so no external pointers to clean up.
-  for (int i = 0; i < _queue_count; i++) {
-    int index = (_queue_head + i) % MAX_QUEUE_SIZE;
-    memset(&_packet_queue[index], 0, sizeof(QueuedPacket));
-  }
-
-  _queue_count = 0;
-  _queue_head = 0;
-  _queue_tail = 0;
-  memset(_packet_queue, 0, sizeof(_packet_queue));
-  #endif
-
-  // Disconnect and delete persistent MQTT clients. teardownSlot() intentionally
-  // only disconnects; destruction happens here so the mbedTLS contexts survive
-  // the reconfigure/reconnect hot path.
-  for (int i = 0; i < RUNTIME_MQTT_SLOTS; i++) {
-    teardownSlot(i);
-  }
-  destroySlotClients();
-
-  // Timezone is inline class storage (_timezone_storage) since Phase 3 of
-  // the MQTT memory-defrag work — nothing to delete. _timezone always
-  // points at &_timezone_storage and stays valid for the bridge lifetime.
-
-  releaseRuntimeBuffers();
-  // JSON documents are StaticJsonDocument inline members — no heap allocation to free.
-
+  // Timezone is inline class storage (_timezone_storage) — nothing to delete.
+  // JSON documents are StaticJsonDocument inline members — no heap to free.
   _initialized = false;
   _slots_setup_done = false;  // Reset so deferred setup runs again on next begin()
-  MQTT_DEBUG_PRINTLN("MQTT Bridge stopped");
+  MQTT_DEBUG_PRINTLN("MQTT Bridge stopped (%s)",
+                     _lifecycle.stopTimedOut() ? "forced/timeout — OTA blocked" : "clean");
+}
+
+// ---------------------------------------------------------------------------
+// LifecycleOps — binds MQTTLifecycle::Ops (the pure, host-tested spec) to the
+// FreeRTOS / PsychicMqttClient runtime. Every method runs on the loop task
+// (Core 1): the Coordinator that calls them is driven only from begin()/end().
+// ---------------------------------------------------------------------------
+uint32_t MQTTBridge::LifecycleOps::nowMs() {
+  return (uint32_t)millis();
+}
+
+void MQTTBridge::LifecycleOps::startTask() {
+  // No-op: begin() owns task/queue/buffer creation and its rollback paths. The
+  // Coordinator is synced to Running there via requestStart()/onTaskStarted().
+}
+
+void MQTTBridge::LifecycleOps::deliverStop() {
+  // Clear any stale ack before raising the request (same ordering as the NTP
+  // handshake: clear the done-flag, then set the request). The MQTT task polls
+  // _stop_requested at the top of mqttTaskLoop().
+  _b->_stop_acked = false;
+  _b->_stop_requested = true;
+}
+
+void MQTTBridge::LifecycleOps::releaseResources() {
+  MQTTBridge* b = _b;
+#ifdef ESP_PLATFORM
+  // stopTimedOut() is set before this effect fires (Coordinator::dispatch), so
+  // it reliably distinguishes a clean ack from the timeout fallback.
+  const bool dirty = b->_lifecycle.stopTimedOut();
+  if (dirty && !b->_stop_acked) {
+    // Reviewed fallback: the task never acknowledged (likely wedged in mbedTLS).
+    // Force-kill it and tear down clients here on Core 1 — the pre-cooperative
+    // behavior — accepting the heap risk. The dirty latch keeps OTA flashing
+    // blocked (canFlashAfterStop() == false) so firmware is never written after
+    // this path.
+    if (b->_mqtt_task_handle != nullptr) {
+      vTaskDelete(b->_mqtt_task_handle);
+    }
+    for (int i = 0; i < RUNTIME_MQTT_SLOTS; i++) b->teardownSlot(i);
+    b->destroySlotClients();
+  }
+  // Clean path (or a task that acked right at the deadline): the MQTT task
+  // already disconnected/deleted its clients on Core 0 and self-terminated, so
+  // we must NOT touch slots here (that would be a cross-core double-delete).
+  // Just drop our handle reference; FreeRTOS reclaims the self-deleted task's
+  // dynamically-allocated stack/TCB in the idle task.
+  b->_mqtt_task_handle = nullptr;
+
+  // Free the PSRAM task stack (nullptr for dynamic tasks — no-op).
+  psram_free(b->_mqtt_task_stack);
+  b->_mqtt_task_stack = nullptr;
+
+  // Drain and delete the FreeRTOS packet queue (value-copied packets, no
+  // external pointers to clean up). Safe on Core 1: not a TLS resource.
+  if (b->_packet_queue_handle != nullptr) {
+    QueuedPacket queued;
+    while (xQueueReceive(b->_packet_queue_handle, &queued, 0) == pdTRUE) {
+      b->_queue_count--;
+    }
+    vQueueDelete(b->_packet_queue_handle);
+    b->_packet_queue_handle = nullptr;
+  }
+  #if defined(BOARD_HAS_PSRAM)
+  psram_free(b->_packet_queue_storage);
+  #endif
+  b->_packet_queue_storage = nullptr;
+#else
+  // Non-ESP32 circular buffer + synchronous client teardown (unchanged behavior).
+  for (int i = 0; i < b->_queue_count; i++) {
+    int index = (b->_queue_head + i) % MAX_QUEUE_SIZE;
+    memset(&b->_packet_queue[index], 0, sizeof(QueuedPacket));
+  }
+  b->_queue_count = 0;
+  b->_queue_head = 0;
+  b->_queue_tail = 0;
+  memset(b->_packet_queue, 0, sizeof(b->_packet_queue));
+  for (int i = 0; i < RUNTIME_MQTT_SLOTS; i++) b->teardownSlot(i);
+  b->destroySlotClients();
+#endif
+
+  b->releaseRuntimeBuffers();
+}
+
+void MQTTBridge::LifecycleOps::onStopComplete(bool clean) {
+  MQTT_DEBUG_PRINTLN("MQTT stop %s", clean
+                     ? "acknowledged (clean)"
+                     : "TIMED OUT (dirty; OTA flashing withheld)");
 }
 
 // ---------------------------------------------------------------------------
@@ -1000,6 +1108,22 @@ void MQTTBridge::mqttTaskLoop() {
   static unsigned long last_agent_log = 0;
   #endif
   while (true) {
+    // Cooperative stop (Phase 5). end() on the loop task (Core 1) set this flag.
+    // Tear down our own clients HERE on Core 0 — where the mbedTLS/transport
+    // state lives — instead of letting Core 1 free them after a blind
+    // vTaskDelete. Acknowledge LAST so end() only frees the queue/buffers once
+    // this teardown has completed, then self-terminate via the mqttTask()
+    // trampoline (vTaskDelete(nullptr)).
+    if (_stop_requested) {
+      MQTT_DEBUG_PRINTLN("MQTT task: cooperative stop — tearing down clients on Core 0");
+      for (int i = 0; i < RUNTIME_MQTT_SLOTS; i++) {
+        teardownSlot(i);
+      }
+      destroySlotClients();
+      _stop_acked = true;   // release semantics: set only after teardown is done
+      return;
+    }
+
     #ifdef MQTT_MEMORY_DEBUG
     // #region agent log
     unsigned long now_loop = millis();

--- a/src/helpers/bridges/MQTTBridge.cpp
+++ b/src/helpers/bridges/MQTTBridge.cpp
@@ -474,13 +474,30 @@ void MQTTBridge::formatSlotDiagReply(char* buf, size_t bufsize, int slot_index) 
 }
 
 // Bounded cooperative-stop timeout for end() (see MQTTLifecycle::Coordinator).
-// Phase 0 TODO: characterize on hardware — mbedTLS teardown over wss with a
-// DOWN broker — before this ships. The placeholder is chosen conservatively:
-// long enough for a real cooperative client teardown (per-slot disconnect + the
-// existing 50 ms settle delays across RUNTIME_MQTT_SLOTS), short enough to bound
-// the loop-task stall and the OTA/restart wait. A stop that exceeds this is
-// treated as dirty: the task is force-killed and OTA flashing is withheld.
-static const uint32_t MQTT_STOP_TIMEOUT_MS = 8000;
+// Phase 0 hardware characterization (2026-07-19, Heltec V3 non-PSRAM + V4 PSRAM,
+// see STABILITY_TESTABILITY_HANDOFF.md): a real mbedTLS/wss client teardown
+// (disconnect + esp_mqtt_client_destroy) takes ~5-6 s per CONNECTED slot, applied
+// SEQUENTIALLY in destroySlotClients(). So the safe timeout scales with the
+// number of slots being torn down, not a single constant: a flat 8 s tripped the
+// dirty/force-kill fallback on a healthy 2-slot non-PSRAM node (~11-12 s) and a
+// normal 3-slot PSRAM node (~16 s), which withholds OTA on healthy devices.
+//
+// The budget below gives generous headroom (~8 s/slot vs the ~5-6 s measured)
+// plus a fixed base for WiFi/queue/buffer teardown. Headroom is nearly free:
+// end() returns as soon as the task acks (it checks _stop_acked before ticking
+// the timeout), so a larger bound does NOT slow a healthy stop — it only length-
+// ens the wait before force-killing a genuinely wedged task. The timeout is set
+// per stop in end() via computeStopTimeoutMs() based on the enabled-slot count.
+static const uint32_t MQTT_STOP_TIMEOUT_BASE_MS     = 5000;   // fixed teardown overhead
+static const uint32_t MQTT_STOP_TIMEOUT_PER_SLOT_MS = 8000;   // ~5-6 s measured + headroom
+
+// Slot-scaled cooperative-stop timeout. `slots` is the number of MQTT slots that
+// will be torn down (enabled/connected); clamped to >=1 so a zero-slot bridge
+// still budgets for the base teardown.
+static inline uint32_t mqttStopTimeoutForSlots(int slots) {
+  if (slots < 1) slots = 1;
+  return MQTT_STOP_TIMEOUT_BASE_MS + MQTT_STOP_TIMEOUT_PER_SLOT_MS * (uint32_t)slots;
+}
 
 // ---------------------------------------------------------------------------
 // Constructor
@@ -525,7 +542,9 @@ MQTTBridge::MQTTBridge(NodePrefs *prefs, MQTTPrefs *obs, mesh::PacketManager *mg
 #endif
       // Cooperative lifecycle: _lifecycle_ops must be constructed before
       // _lifecycle (declaration order guarantees this) so the reference binds.
-      , _lifecycle_ops(this), _lifecycle(_lifecycle_ops, MQTT_STOP_TIMEOUT_MS)
+      // Seed with the worst-case (max runtime slots) budget; end() recomputes the
+      // slot-scaled timeout before each stop via setStopTimeoutMs().
+      , _lifecycle_ops(this), _lifecycle(_lifecycle_ops, mqttStopTimeoutForSlots(RUNTIME_MQTT_SLOTS))
 {
   // Initialize default values
   strncpy(_origin, "MeshCore-Repeater", sizeof(_origin) - 1);
@@ -897,6 +916,20 @@ void MQTTBridge::end() {
 
   // Stop new diagnostic reads through the singleton before teardown begins.
   s_mqtt_bridge_instance = nullptr;
+
+  // Size the stop timeout to the work about to happen: each enabled slot's
+  // mbedTLS/wss client takes ~5-6 s to disconnect + destroy, sequentially (Phase
+  // 0 hardware characterization). A flat bound force-killed healthy multi-slot
+  // nodes and withheld OTA; the slot-scaled budget lets a normal teardown ack
+  // cleanly. Count enabled slots (the ones that connect); a disabled slot's
+  // client destroys quickly. Must run BEFORE requestStop() arms the window.
+  int stop_slots = 0;
+  for (int i = 0; i < RUNTIME_MQTT_SLOTS; i++) {
+    if (_slots[i].enabled) stop_slots++;
+  }
+  _lifecycle.setStopTimeoutMs(mqttStopTimeoutForSlots(stop_slots));
+  MQTT_DEBUG_PRINTLN("MQTT stop: %d enabled slot(s), timeout %lu ms",
+                     stop_slots, (unsigned long)_lifecycle.stopTimeoutMs());
 
   // Cooperative shutdown (Phase 5). Request the stop, then let the lifecycle
   // Coordinator drive it. On ESP32 the MQTT task (Core 0) tears down its own

--- a/src/helpers/bridges/MQTTBridge.cpp
+++ b/src/helpers/bridges/MQTTBridge.cpp
@@ -661,7 +661,7 @@ void MQTTBridge::begin() {
   // would re-run allocation and re-create the task, leaking the previous
   // queue/task. Guard here instead of relying on caller discipline.
   if (_initialized) {
-    MQTT_DEBUG_PRINTLN("MQTT Bridge already running — begin() ignored");
+    MQTT_DEBUG_PRINTLN("MQTT Bridge already running - begin() ignored");
     return;
   }
 
@@ -910,7 +910,7 @@ void MQTTBridge::end() {
 
   // Idempotent stop: nothing to tear down if we never started (or already stopped).
   if (!_initialized) {
-    MQTT_DEBUG_PRINTLN("MQTT Bridge already stopped — end() ignored");
+    MQTT_DEBUG_PRINTLN("MQTT Bridge already stopped - end() ignored");
     return;
   }
 
@@ -966,7 +966,7 @@ void MQTTBridge::end() {
   _initialized = false;
   _slots_setup_done = false;  // Reset so deferred setup runs again on next begin()
   MQTT_DEBUG_PRINTLN("MQTT Bridge stopped (%s)",
-                     _lifecycle.stopTimedOut() ? "forced/timeout — OTA blocked" : "clean");
+                     _lifecycle.stopTimedOut() ? "forced/timeout - OTA blocked" : "clean");
 }
 
 // ---------------------------------------------------------------------------
@@ -1148,7 +1148,7 @@ void MQTTBridge::mqttTaskLoop() {
     // this teardown has completed, then self-terminate via the mqttTask()
     // trampoline (vTaskDelete(nullptr)).
     if (_stop_requested) {
-      MQTT_DEBUG_PRINTLN("MQTT task: cooperative stop — tearing down clients on Core 0");
+      MQTT_DEBUG_PRINTLN("MQTT task: cooperative stop - tearing down clients on Core 0");
       for (int i = 0; i < RUNTIME_MQTT_SLOTS; i++) {
         teardownSlot(i);
       }
@@ -1256,7 +1256,7 @@ void MQTTBridge::mqttTaskLoop() {
           }
           char reason[80];
           if (!isSlotReady(i, reason, sizeof(reason))) {
-            MQTT_DEBUG_PRINTLN("MQTT%d not ready — run '%s' to connect", i + 1, reason);
+            MQTT_DEBUG_PRINTLN("MQTT%d not ready - run '%s' to connect", i + 1, reason);
             continue;
           }
           setupSlot(i);
@@ -1498,7 +1498,7 @@ void MQTTBridge::setupSlot(int index) {
   // Persistent client is expected to have been allocated by initSlotClients().
   // If it hasn't, we can't proceed — bail loudly rather than silently leaking.
   if (slot.client == nullptr) {
-    MQTT_DEBUG_PRINTLN("MQTT%d: setupSlot before initSlotClients() — skipping", index + 1);
+    MQTT_DEBUG_PRINTLN("MQTT%d: setupSlot before initSlotClients() - skipping", index + 1);
     return;
   }
 
@@ -2270,7 +2270,7 @@ void MQTTBridge::applySlotPreset(int slot_index, const char* preset_name) {
     if (_initialized) {
       char reason[80];
       if (!isSlotReady(slot_index, reason, sizeof(reason))) {
-        MQTT_DEBUG_PRINTLN("MQTT%d (%s) not ready — run '%s' to connect", slot_index + 1, preset_name, reason);
+        MQTT_DEBUG_PRINTLN("MQTT%d (%s) not ready - run '%s' to connect", slot_index + 1, preset_name, reason);
         return;
       }
       setupSlot(slot_index);
@@ -2301,7 +2301,7 @@ void MQTTBridge::checkConfigurationMismatch() {
   if (_obs->mqtt_packets_enabled && !_obs->mqtt_rx_enabled && _obs->mqtt_tx_enabled == 0) {
     unsigned long now = millis();
     if (_last_config_warning == 0 || (now - _last_config_warning > CONFIG_WARNING_INTERVAL)) {
-      MQTT_DEBUG_PRINTLN("MQTT: Both mqtt.rx and mqtt.tx are off — no packets will be published. Run 'set mqtt.rx on' or 'set mqtt.tx on' to fix.");
+      MQTT_DEBUG_PRINTLN("MQTT: Both mqtt.rx and mqtt.tx are off - no packets will be published. Run 'set mqtt.rx on' or 'set mqtt.tx on' to fix.");
       _last_config_warning = now;
     }
   } else {

--- a/src/helpers/bridges/MQTTBridge.h
+++ b/src/helpers/bridges/MQTTBridge.h
@@ -9,6 +9,7 @@
 #include <Timezone.h>
 #include "helpers/JWTHelper.h"
 #include "helpers/MQTTPresets.h"
+#include "helpers/MQTTLifecycle.h"
 
 #ifdef WITH_SNMP
 class MeshSNMPAgent;  // Forward declaration
@@ -221,6 +222,16 @@ private:
   NtpDiagResult _ntp_diag_results[kMaxNtpServers];
   int _ntp_diag_count;
 
+  // Cooperative-shutdown handshake (Phase 5). The loop task (Core 1) raises
+  // _stop_requested through the lifecycle Coordinator; the MQTT task (Core 0)
+  // sees it, tears down its own clients on Core 0 (where the mbedTLS contexts
+  // live), sets _stop_acked LAST, and self-terminates. end() waits for the ack
+  // before freeing the queue/buffers. Plain volatile matches the existing
+  // NTP/reconfigure handshake idiom above; replacing all of these with a command
+  // channel / task notifications is explicitly deferred (see MQTT_OWNERSHIP.md).
+  volatile bool _stop_requested = false;
+  volatile bool _stop_acked = false;
+
   // Timezone handling.
   // _timezone_storage is inline class storage (zero heap) that is reconfigured
   // via setRules() whenever the preferred timezone string changes. _timezone
@@ -382,6 +393,27 @@ private:
   void allocateRuntimeBuffers();
   void releaseRuntimeBuffers();
 
+  // --- Cooperative lifecycle (Phase 5) ---------------------------------------
+  // The pure state machine, bounded stop timeout, and OTA barrier live in
+  // src/helpers/MQTTLifecycle.h and are host-tested by test/test_mqtt_lifecycle/.
+  // This nested Ops binds that spec to FreeRTOS/PsychicMqttClient. The
+  // Coordinator is owned and driven ONLY by the loop task (Core 1) from
+  // begin()/end(); the MQTT task (Core 0) communicates solely through the
+  // _stop_requested/_stop_acked flags above. Methods are defined in the .cpp.
+  class LifecycleOps : public MQTTLifecycle::Ops {
+   public:
+    explicit LifecycleOps(MQTTBridge* bridge) : _b(bridge) {}
+    uint32_t nowMs() override;
+    void startTask() override;
+    void deliverStop() override;
+    void releaseResources() override;
+    void onStopComplete(bool clean) override;
+   private:
+    MQTTBridge* _b;
+  };
+  LifecycleOps _lifecycle_ops;
+  MQTTLifecycle::Coordinator _lifecycle;
+
   // Observer config (MQTT/WiFi/timezone/SNMP/alert), persisted to /mqtt_prefs.
   // _prefs (held by BridgeBase) still provides upstream fields (freq/sf/node_name…).
   MQTTPrefs* _obs = nullptr;
@@ -430,6 +462,11 @@ public:
   int getConnectedBrokers() const;
   int getQueueSize() const;
   bool isReady() const;
+  /** True only after a CLEAN cooperative stop — end() received the MQTT task's
+   *  acknowledgment within the timeout. A timed-out/forced stop returns false so
+   *  OTA flashing is withheld until a clean start/stop cycle. Mirrors
+   *  MQTTLifecycle::mayBeginFlash(); read on the loop task (Core 1). */
+  bool canFlashAfterStop() const { return _lifecycle.mayBeginFlash(); }
 
   static unsigned long getWifiConnectedAtMillis();
 


### PR DESCRIPTION
## Summary

Phase 5 of `STABILITY_TESTABILITY_HANDOFF.md`: wire the Phase 4 `MQTTLifecycle`
state machine into `MQTTBridge` so shutdown is **cooperative** instead of a blind
`vTaskDelete`. This fixes the observed OTA teardown heap panic (killing the MQTT
task mid-mbedTLS, then freeing client buffers on a corrupted heap).

**Scope: the minimal cooperative-shutdown unit** — deliberately the smallest
change that fixes the panic as one reviewable diff. Per the handoff's
Change-Control Discipline, the larger ownership rewiring is **deferred**.

## What changed

- `MQTTBridge` owns a `MQTTLifecycle::Coordinator`, driven **only** by the loop
  task (Core 1) from `begin()`/`end()`. A nested `LifecycleOps` binds the pure,
  host-tested `Ops` spec to FreeRTOS/PsychicMqttClient. The MQTT task (Core 0)
  communicates solely through two `volatile` flags (`_stop_requested`/`_stop_acked`).
- **`end()`**: requests a cooperative stop; the MQTT task tears down its **own**
  clients on Core 0 (where the mbedTLS contexts live), sets `_stop_acked` last,
  and self-terminates. `end()` waits (bounded) for the ack, then frees the
  queue/buffers. Idempotent.
- **Reviewed fallback**: on stop timeout the task is force-killed and torn down
  on Core 1 (the old behavior), but a **dirty latch** is set so
  `canFlashAfterStop()` is false and OTA flashing is withheld.
- **`begin()`**: idempotent double-call guard; syncs the Coordinator to `Running`.
- **OTA teardown barrier**: `simple_repeater`'s deferred-OTA fire site aborts and
  resumes the bridge unless the preceding `end()` reported a clean stop.

## Deferred (not in this PR)

- Replacing the `volatile` NTP/reconfigure handshakes with a command channel.
- Publishing a plain-data status snapshot and repointing the `AlertReporter` /
  `buildStatsJson` instance-pointer consumers (`MQTT_OWNERSHIP.md` sections 1-2).

These are not required to fix the OTA panic and would enlarge the merge-sensitive
diff. Tracked for a Phase 5b / Phase 6.

## Verification

- Native suite green (13 dirs, incl. `test_mqtt_lifecycle` — the OTA-barrier and
  teardown-matrix cases that this PR's production wiring realizes).
- Both observer firmware smoke builds compile and link:
  `Heltec_v3_repeater_observer_mqtt` (non-PSRAM) and
  `T_Beam_S3_Supreme_SX1262_repeater_observer_mqtt` (PSRAM).

## Not done here - needs a human / hardware

- **Not hardware-validated.** Repeated start/stop, OTA success/abort/timeout, and
  heap/stack/task-count soak are the Phase 7 gate.
- **`MQTT_STOP_TIMEOUT_MS` is a conservative 8 s placeholder** (single named
  constant). Phase 0 must characterize it against real mbedTLS teardown over
  `wss` with a down broker before this ships.

Base is `webconfig` (this builds on the Phase 4 commit `9d5bd6f8`).
