### PR TITLE
Resolve WebConfigBatch spec review nits (line ref, keep-stale reboot caveat, constants freeze)

### DIFF
--- a/STABILITY_TESTABILITY_HANDOFF.md
+++ b/STABILITY_TESTABILITY_HANDOFF.md
@@ -624,12 +624,27 @@ into the pure policy seams and covered:
 
 The **WebConfig POST/result/reboot/stop state machine** (the largest gap) now
 has a pure, host-tested SPEC — `src/helpers/WebConfigBatch.h` +
-`test/test_webconfig_batch/` on branch `phase6/webconfig-batch-seam` — that
-faithfully characterizes the accept/drain/result/reboot/stop decisions currently
-inline in `WebConfigServer.cpp`. Like Phase 4's `MQTTLifecycle.h`, it is
-**spec-first and NOT yet wired**: rewiring the hardware-tuned server to consume it
-(so it becomes load-bearing and non-drifting) is a deliberately separate,
-hardware-validated follow-up.
+`test/test_webconfig_batch/` (merged to `webconfig`) — that faithfully
+characterizes the accept/drain/result/reboot/stop decisions currently inline in
+`WebConfigServer.cpp`. A line-by-line faithfulness review confirmed it; the
+follow-up nits it raised are now resolved: the one stale line reference was
+corrected, and the batch constants are literal-pinned by a freeze test
+(`ConstantsMatchTheWebConfigServerSource`), so a spec/source constant drift trips
+the native suite rather than going silent.
+
+Like Phase 4's `MQTTLifecycle.h`, it is **spec-first and NOT yet wired**:
+rewiring the hardware-tuned server to consume it (so it becomes load-bearing and
+non-drifting) is a deliberately separate, hardware-validated follow-up.
+**Porting constraint (fleet behavior) — keep-stale reboot deadline:** production
+never clears `_reboot_at` on a new POST-accept (`WebConfigServer.cpp:699-710`) —
+it clears it only on a full server stop/reset (`.cpp:235`) — so a prior
+fully-OK reboot batch's armed deadline *survives into a later batch and still
+fires*. `WebConfigBatch::finishRebootAt()` returns `0` for the no-reboot case, so
+a naive `_reboot_at = finishRebootAt(...)` during wiring would silently **cancel**
+that surviving reboot and change fleet behavior. The port must assign only when
+the result is non-zero (preserving keep-stale semantics), or change the behavior
+deliberately and cover it with a test. The hazard is documented at the
+`finishRebootAt()` definition in the header.
 
 Still open (each a good follow-up PR): wiring `WebConfigServer.cpp` to the
 `WebConfigBatch` spec above, and the **queue-orchestration** behaviors (FIFO

--- a/src/helpers/WebConfigBatch.h
+++ b/src/helpers/WebConfigBatch.h
@@ -83,7 +83,7 @@ static inline PostOutcome classifyPost(State state, bool reqid_matches_current,
   return PostOutcome::Accept;
 }
 
-// The state string a Replay body reports mirrors the batch state (.cpp:640):
+// The state string a Replay body reports mirrors the batch state (.cpp:639):
 // "done" when the matched batch already finished, else "pending".
 static inline const char* replayStateName(State state) {
   return state == State::Done ? "done" : "pending";
@@ -119,7 +119,17 @@ static inline bool drainFinished(int batch_next_after_increment, int batch_count
 
 // On finish, a reboot-requested + all-ok batch arms the 30 s fallback deadline;
 // a partially-failed batch (all_ok == false) never reboots (.cpp:324-333).
-// Returns the reboot_at deadline, or 0 for "no reboot scheduled".
+// Returns the reboot_at deadline, or 0 for "no reboot scheduled by THIS finish".
+//
+// KEEP-STALE CAUTION for a future load-bearing port: production only writes
+// _reboot_at here and at the result-read arm (.cpp:784), and clears it solely on
+// a full server stop/reset (.cpp:235). A new POST-accept (.cpp:699-710) resets
+// the batch fields but deliberately does NOT clear _reboot_at, so a prior
+// fully-OK reboot batch's deadline SURVIVES into a later batch and still fires.
+// Because this returns 0 for the no-reboot case, a naive
+// `_reboot_at = finishRebootAt(...)` would CANCEL that surviving deadline and
+// silently change fleet reboot behavior. A port must assign only when the result
+// is non-zero (preserving keep-stale), or change the behavior deliberately+tested.
 static inline uint32_t finishRebootAt(bool batch_reboot, bool batch_all_ok, uint32_t now) {
   return (batch_reboot && batch_all_ok) ? scheduleAt(now, kRebootFallbackMs) : 0u;
 }

--- a/test/test_webconfig_batch/test_webconfig_batch.cpp
+++ b/test/test_webconfig_batch/test_webconfig_batch.cpp
@@ -200,6 +200,23 @@ TEST(WebConfigBatch, ScheduleAtNeverReturnsTheUnscheduledSentinel) {
   EXPECT_EQ(1u, Batch::scheduleAt(just_below_wrap, 1));
 }
 
+// --------------------------------------------------------------------------
+// Constants freeze — these mirror WebConfigServer verbatim (kMaxBatch=MAX_BATCH
+// .h:90, kStopWarnMs=STOP_WARN_MS .h:95, and the 25/30000/3000 ms literals at
+// .cpp:296/331/784). The behavioral tests above route each constant through a
+// helper, so they would still pass if a value silently drifted; this pins the raw
+// values so any edit to the spec side forces a deliberate re-check against the
+// source (the header is hand-synced, not yet wired). If the source changes, update
+// both the constant AND this test together.
+// --------------------------------------------------------------------------
+TEST(WebConfigBatch, ConstantsMatchTheWebConfigServerSource) {
+  EXPECT_EQ(24, Batch::kMaxBatch);              // WebConfigServer.h:90 MAX_BATCH
+  EXPECT_EQ(25u, Batch::kDrainPacingMs);        // .cpp:296 inter-command gap
+  EXPECT_EQ(30000u, Batch::kRebootFallbackMs);  // .cpp:331 drain-finish fallback
+  EXPECT_EQ(3000u, Batch::kRebootConfirmMs);    // .cpp:784 first result-read arm
+  EXPECT_EQ(10000u, Batch::kStopWarnMs);        // WebConfigServer.h:95 STOP_WARN_MS
+}
+
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();


### PR DESCRIPTION
## Summary

Follow-up to the `WebConfigBatch` faithfulness review (Phase 6 part 2, merged to `webconfig` via `0e7a07af`). Resolves the three low-severity nits that review raised. All are polish on a spec that is **not yet load-bearing**; **no runtime behavior changes**.

## What changed

1. **Line-ref fix** — `replayStateName`'s comment cited `WebConfigServer.cpp:640` for the batch-state ternary; it's at `:639` (640 is `ack["count"]`). Verified against the source.
2. **Keep-stale reboot hazard documented** — production never clears `_reboot_at` on a new POST-accept (`.cpp:699-710`); it clears it only on a full server stop/reset (`.cpp:235`). So a prior fully-OK reboot batch's armed deadline **survives into a later batch and still fires**. Since `finishRebootAt()` returns `0` for the no-reboot case, a naive `_reboot_at = finishRebootAt(...)` during a future wiring would silently **cancel** that surviving reboot and change fleet behavior. Flagged at the `finishRebootAt()` definition and as a Phase 6 porting constraint in the handoff.
3. **Constants freeze test** — new `ConstantsMatchTheWebConfigServerSource` literal-pins `kMaxBatch` (24), `kDrainPacingMs` (25), `kRebootFallbackMs` (30000), `kRebootConfirmMs` (3000), `kStopWarnMs` (10000). The behavioral tests route each constant through a helper, so a silent drift would still pass; this trips the native suite instead. All five values re-verified against `WebConfigServer.{h,cpp}`.

Handoff (`STABILITY_TESTABILITY_HANDOFF.md`) Phase 6 section updated: nits marked resolved and the keep-stale reboot constraint added as explicit porting guidance for the future wiring PR.

## Verification

- Native suite green (14 dirs), including the new freeze case.
- No production code path touched — header comments, one test, and doc only.

Base is `webconfig`.