### PR TITLE
fix(repeater): restore node name at top of home screen

### DIFF
--- a/examples/simple_repeater/UITask.cpp
+++ b/examples/simple_repeater/UITask.cpp
@@ -135,7 +135,8 @@ void UITask::renderCurrScreen() {
       return;
     }
 #endif
-    // node name    _display->setCursor(0, 0);
+    // node name
+    _display->setCursor(0, 0);
     _display->setTextSize(1);
     _display->setColor(DisplayDriver::GREEN);
     _display->print(_node_prefs->node_name);


### PR DESCRIPTION
## Problem

On the observer home screen the node name went missing from the top line. Instead the name trailed the `IP:` line and wrapped below it, e.g.:

```
(blank)
FREQ: <freq> SF<sf>
BW: <bw> CR: 5
IP: <ip>MQTT
Observer 61
```

(device name here is "MQTT Observer 61")

## Cause

The merge commit `15e3400a` ("merge: upstream/dev into webconfig") collapsed the `// node name` comment and its `_display->setCursor(0, 0)` call onto a single line in `examples/simple_repeater/UITask.cpp`:

```cpp
// node name    _display->setCursor(0, 0);
```

That commented out the cursor reset, so `_display->print(_node_prefs->node_name)` drew the name at whatever cursor position was left after the previous frame — the end of the `IP:` line — instead of at the top.

## Fix

Split the comment and `setCursor(0, 0)` back onto separate lines so the name is drawn at `(0, 0)` again. This restores the structure that exists on the pre-merge history and on the sibling webconfig branch.

One-line change; no functional code added.