### PR TITLE
Add idahomesh broker preset

### DIFF
--- a/MQTT_IMPLEMENTATION.md
+++ b/MQTT_IMPLEMENTATION.md
@@ -160,6 +160,7 @@ below documents the current build.
 | `wcmesh` | `wss://mqtt.wcmesh.com:443` | JWT | — |
 | `atvirastinklas` | `wss://mqtt-mc.atvirastinklas.lt:443` | JWT | — |
 | `gomesh` | `wss://mqtt.gomesh.dev:443` | JWT | — |
+| `idahomesh` | `wss://mqtt.idahomesh.org:443/mqtt` | JWT | — |
 | `custom` | your own broker | User/pass, or JWT when `mqttN.audience` is set | `set mqttN.server` (see [custom broker setup](#custom-brokers)) |
 | `none` | (slot disabled) | — | — |
 

--- a/src/helpers/MQTTPresets.h
+++ b/src/helpers/MQTTPresets.h
@@ -127,7 +127,7 @@ static const char ISRG_ROOT_X1[] PROGMEM =
     "-----END CERTIFICATE-----\n";
 
 // Number of built-in presets
-static const int MQTT_PRESET_COUNT = 33;
+static const int MQTT_PRESET_COUNT = 34;
 
 // Built-in preset definitions (stored in flash)
 static const MQTTPresetDef MQTT_PRESETS[MQTT_PRESET_COUNT] = {
@@ -173,6 +173,7 @@ static const MQTTPresetDef MQTT_PRESETS[MQTT_PRESET_COUNT] = {
     { "atvirastinklas","wss://mqtt-mc.atvirastinklas.lt:443",      "mqtt-mc.atvirastinklas.lt",       GTS_ROOT_R4,   MQTT_AUTH_JWT,      MQTT_TOPIC_MESHCORE,  0,       true,   55,      nullptr,     nullptr     },
     // JWT token auth; LE Gen-Y ECDSA chain (YE2 → Root YE → X2) still anchors at ISRG Root X1.
     { "gomesh",        "wss://mqtt.gomesh.dev:443",               "mqtt.gomesh.dev",                 ISRG_ROOT_X1,  MQTT_AUTH_JWT,      MQTT_TOPIC_MESHCORE,  0,       true,   55,      nullptr,     nullptr     },
+    { "idahomesh",     "wss://mqtt.idahomesh.org:443/mqtt",       "mqtt.idahomesh.org",              ISRG_ROOT_X1,  MQTT_AUTH_JWT,      MQTT_TOPIC_MESHCORE,  0,       true,   55,      nullptr,     nullptr     },
 };
 
 // Find a preset by name, returns nullptr if not found


### PR DESCRIPTION
Adds a preset for the IdahoMesh community broker (feeds map.idahomesh.org).

`idahomesh` — `wss://mqtt.idahomesh.org:443/mqtt`, JWT (aud `mqtt.idahomesh.org`), Let's Encrypt (ISRG Root X1, already bundled). Bumps `MQTT_PRESET_COUNT` 33→34 and updates the preset table.
