### PR TITLE
Added support for the second RF slot on the Station G3

### DIFF
--- a/variants/station_g3_esp32_rf2/platformio.ini
+++ b/variants/station_g3_esp32_rf2/platformio.ini
@@ -1,0 +1,41 @@
+; Station G3 ESP32 second RF slot (RF2)
+;
+; Reuses the existing Station G3 environments and source code while
+; overriding only the GPIOs that differ between RF1 and RF2.
+
+[station_g3_esp32_rf2_pins]
+build_unflags =
+  ; Remove RF1 pin definitions inherited from Station_G3_ESP32
+  -D P_LORA_DIO_1
+  -D P_LORA_NSS
+  -D P_LORA_RESET
+  -D P_LORA_BUSY
+  -D P_LORA_SCLK
+  -D P_LORA_MISO
+  -D P_LORA_MOSI
+  -D P_PRIMARY_LNA_EN
+
+build_flags =
+  ; Station G3 RF2 pin definitions
+  -D P_LORA_DIO_1=2
+  -D P_LORA_NSS=43
+  -D P_LORA_RESET=44
+  -D P_LORA_BUSY=1
+  -D P_LORA_SCLK=39
+  -D P_LORA_MISO=41
+  -D P_LORA_MOSI=40
+  -D P_PRIMARY_LNA_EN=42
+
+
+[env:Station_G3_ESP32_RF2_repeater]
+extends = env:Station_G3_ESP32_repeater
+build_flags =
+  ${env:Station_G3_ESP32_repeater.build_flags}
+  ${station_g3_esp32_rf2_pins.build_flags}
+
+
+[env:Station_G3_ESP32_RF2_repeater_observer_mqtt]
+extends = env:Station_G3_ESP32_repeater_observer_mqtt
+build_flags =
+  ${env:Station_G3_ESP32_repeater_observer_mqtt.build_flags}
+  ${station_g3_esp32_rf2_pins.build_flags}


### PR DESCRIPTION
Added a new `variants/station_g3_esp32_rf2/platformio.ini` configuration, which inherits the existing Station G3 environments and replaces only the RF2 slot-specific pin definitions. This avoids duplicating the Station G3 board implementation and allows future Station G3 firmware changes to continue applying to both RF slots.