### PR TITLE
feat(station-g3): add second RF slot (r2) build targets

### DIFF
--- a/MQTT_IMPLEMENTATION.md
+++ b/MQTT_IMPLEMENTATION.md
@@ -211,6 +211,8 @@ pio run -e Station_G2_repeater_observer_mqtt
 # Station G3 (ESP32)
 pio run -e Station_G3_ESP32_repeater_observer_mqtt
 pio run -e Station_G3_ESP32_room_server_observer_mqtt
+pio run -e Station_G3_ESP32_r2_repeater_observer_mqtt   # second RF slot
+pio run -e Station_G3_ESP32_r2_room_server_observer_mqtt   # second RF slot
 
 # LilyGo T-LoRa V2.1-1.6 (TTGO LoRa32 V1.0)
 pio run -e LilyGo_TLora_V2_1_1_6_repeater_observer_mqtt
@@ -245,6 +247,8 @@ Some MQTT observer builds use a non-default partition table to accommodate the l
 | `Station_G2_room_server_observer_mqtt` | `default_16MB.csv` | 16 MB | 6.25 MB | 16 MB flash board |
 | `Station_G3_ESP32_repeater_observer_mqtt` | `default_16MB.csv` | 16 MB | 6.25 MB | 16 MB flash board |
 | `Station_G3_ESP32_room_server_observer_mqtt` | `default_16MB.csv` | 16 MB | 6.25 MB | 16 MB flash board |
+| `Station_G3_ESP32_r2_repeater_observer_mqtt` | `default_16MB.csv` | 16 MB | 6.25 MB | Second RF slot; same board and layout as the slot-1 env |
+| `Station_G3_ESP32_r2_room_server_observer_mqtt` | `default_16MB.csv` | 16 MB | 6.25 MB | same |
 | `LilyGo_TBeam_1W_repeater_observer_mqtt` | `default_16MB.csv` | 16 MB | 6.25 MB | Set in `boards/t_beam_1w.json`; required vs implicit `default.csv` |
 | `LilyGo_TBeam_1W_room_server_observer_mqtt` | `default_16MB.csv` | 16 MB | 6.25 MB | same |
 

--- a/variants/station_g3_esp32/platformio.ini
+++ b/variants/station_g3_esp32/platformio.ini
@@ -1,4 +1,7 @@
-[Station_G3_ESP32]
+; The motherboard has two RF daughterboard slots on separate GPIOs, mirrored by its
+; "LNA P" / "LNA S" jumpers. Slot 1 is [Station_G3_ESP32], slot 2 is [Station_G3_ESP32_r2];
+; the slot pins sit in their own sections so neither set of -D flags shadows the other.
+[Station_G3_ESP32_common]
 extends = esp32_base
 board = station-g3-esp32
 build_flags =
@@ -10,17 +13,8 @@ build_flags =
   -D USE_SX1262
   -D RADIO_CLASS=CustomSX1262
   -D WRAPPER_CLASS=CustomSX1262Wrapper
-  -D P_LORA_DIO_1=48
-  -D P_LORA_NSS=11
-  -D P_LORA_RESET=21
-  -D P_LORA_BUSY=47
-  -D P_LORA_SCLK=12
-  -D P_LORA_MISO=14
-  -D P_LORA_MOSI=13
   -D P_PA1_EN=9 ; PA PL1 Mode: LOW/open selects low level, HIGH/short selects high level.
   -D P_PA1_EN_ACTIVE=HIGH
-  -D P_PRIMARY_LNA_EN=10 ; Primary Slot LNA Mode: LOW/open is LNA on, HIGH/short is LNA off.
-  -D P_PRIMARY_LNA_EN_ACTIVE=LOW
   -D LORA_TX_POWER=7 ; SX1262 input power to the Station G3 PA; final output depends on PA PL1/PL2 level.
   -D MAX_LORA_TX_POWER=22
 ;  -D P_LORA_TX_LED=35
@@ -44,6 +38,48 @@ lib_deps =
   ${sensor_base.lib_deps}
   adafruit/Adafruit SH110X @ ~2.1.13
   adafruit/Adafruit GFX Library @ ^1.12.1
+
+; PA PL1 is one board-level jumper shared by both slots, so P_PA1_EN stays in the base above.
+[station_g3_esp32_r1_pins]
+build_flags =
+  -D P_LORA_DIO_1=48
+  -D P_LORA_NSS=11
+  -D P_LORA_RESET=21
+  -D P_LORA_BUSY=47
+  -D P_LORA_SCLK=12
+  -D P_LORA_MISO=14
+  -D P_LORA_MOSI=13
+  -D P_PRIMARY_LNA_EN=10 ; Primary Slot LNA Mode: LOW/open is LNA on, HIGH/short is LNA off.
+  -D P_PRIMARY_LNA_EN_ACTIVE=LOW
+
+; Slot 2 ("LNA S"). P_PRIMARY_LNA_EN keeps its name because LoRaFEMControl knows only one LNA pin.
+[station_g3_esp32_r2_pins]
+build_flags =
+  -D P_LORA_DIO_1=2
+  -D P_LORA_NSS=43
+  -D P_LORA_RESET=44
+  -D P_LORA_BUSY=1
+  -D P_LORA_SCLK=39
+  -D P_LORA_MISO=41
+  -D P_LORA_MOSI=40
+  -D P_PRIMARY_LNA_EN=42 ; Secondary Slot LNA Mode, same polarity as the primary slot.
+  -D P_PRIMARY_LNA_EN_ACTIVE=LOW
+
+[Station_G3_ESP32]
+extends = Station_G3_ESP32_common
+build_flags =
+  ${Station_G3_ESP32_common.build_flags}
+  ${station_g3_esp32_r1_pins.build_flags}
+build_src_filter = ${Station_G3_ESP32_common.build_src_filter}
+lib_deps = ${Station_G3_ESP32_common.lib_deps}
+
+[Station_G3_ESP32_r2]
+extends = Station_G3_ESP32_common
+build_flags =
+  ${Station_G3_ESP32_common.build_flags}
+  ${station_g3_esp32_r2_pins.build_flags}
+build_src_filter = ${Station_G3_ESP32_common.build_src_filter}
+lib_deps = ${Station_G3_ESP32_common.lib_deps}
 
 [env:Station_G3_ESP32_repeater]
 extends = Station_G3_ESP32
@@ -239,6 +275,127 @@ build_src_filter = ${Station_G3_ESP32.build_src_filter}
   +<../examples/simple_room_server>
 lib_deps =
   ${Station_G3_ESP32.lib_deps}
+  ${esp32_ota.lib_deps}
+  elims/PsychicMqttClient@^0.2.4
+  bblanchon/ArduinoJson @ 7.4.3
+  arduino-libraries/NTPClient
+  JChristensen/Timezone
+  paulstoffregen/Time@1.6.1
+  0neblock/SNMP_Agent
+
+[env:Station_G3_ESP32_r2_repeater]
+extends = Station_G3_ESP32_r2
+build_flags =
+  ${Station_G3_ESP32_r2.build_flags}
+  -D ADVERT_NAME='"Station G3 ESP32 Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${Station_G3_ESP32_r2.build_src_filter}
+  +<../examples/simple_repeater>
+lib_deps =
+  ${Station_G3_ESP32_r2.lib_deps}
+  ${esp32_ota.lib_deps}
+
+[env:Station_G3_ESP32_r2_room_server]
+extends = Station_G3_ESP32_r2
+build_src_filter = ${Station_G3_ESP32_r2.build_src_filter}
+  +<../examples/simple_room_server>
+build_flags =
+  ${Station_G3_ESP32_r2.build_flags}
+  -D ADVERT_NAME='"Station G3 ESP32 Room"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D ROOM_PASSWORD='"hello"'
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+lib_deps =
+  ${Station_G3_ESP32_r2.lib_deps}
+  ${esp32_ota.lib_deps}
+
+[env:Station_G3_ESP32_r2_repeater_observer_mqtt]
+extends = Station_G3_ESP32_r2
+board_build.partitions = default_16MB.csv ; standard 16MB partition table
+extra_scripts =
+  ${esp32_base.extra_scripts}
+  pre:scripts/generate_cert_bundle.py
+board_ssl_cert_source = adafruit-full
+board_build.embed_files = src/certs/x509_crt_bundle.bin
+build_flags =
+  ${Station_G3_ESP32_r2.build_flags}
+  -D ADVERT_NAME='"MQTT Observer"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+  -D WITH_MQTT_BRIDGE=1
+  -D MQTT_MAX_PACKET_SIZE=1024
+  -D MQTT_DEBUG=1
+#  -D MESH_PACKET_LOGGING=1
+#  -D MESH_DEBUG=1
+  -D CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=y
+  -D ESP32_CPU_FREQ=160
+  -D WITH_SNMP=1
+#  -D WIFI_SSID='"ssid"'
+#  -D WIFI_PWD='"password"'
+#  -D MQTT_SERVER='"your-mqtt-broker.com"'
+#  -D MQTT_PORT=1883
+#  -D MQTT_USERNAME='"your-username"'
+#  -D MQTT_PASSWORD='"your-password"'
+build_src_filter = ${Station_G3_ESP32_r2.build_src_filter}
+  +<helpers/bridges/MQTTBridge.cpp>
+  +<helpers/MQTTMessageBuilder.cpp>
+  +<helpers/JWTHelper.cpp>
+  +<helpers/SNMPAgent.cpp>
+  +<helpers/ui/SH1106Display.cpp>
+  +<../examples/simple_repeater>
+lib_deps =
+  ${Station_G3_ESP32_r2.lib_deps}
+  ${esp32_ota.lib_deps}
+  elims/PsychicMqttClient@^0.2.4
+  bblanchon/ArduinoJson @ 7.4.3
+  arduino-libraries/NTPClient
+  JChristensen/Timezone
+  paulstoffregen/Time@1.6.1
+  0neblock/SNMP_Agent
+
+[env:Station_G3_ESP32_r2_room_server_observer_mqtt]
+extends = Station_G3_ESP32_r2
+board_build.partitions = default_16MB.csv ; standard 16MB partition table
+extra_scripts =
+  ${esp32_base.extra_scripts}
+  pre:scripts/generate_cert_bundle.py
+board_ssl_cert_source = adafruit-full
+board_build.embed_files = src/certs/x509_crt_bundle.bin
+build_flags =
+  ${Station_G3_ESP32_r2.build_flags}
+  -D ADVERT_NAME='"Station G3 ESP32 Room Observer"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D ROOM_PASSWORD='"hello"'
+  -D WITH_MQTT_BRIDGE=1
+  -D MAX_NEIGHBOURS=50
+  -D MQTT_MAX_PACKET_SIZE=1024
+  -D MQTT_DEBUG=1
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+  -D CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=y
+  -D ESP32_CPU_FREQ=160
+  -D WITH_SNMP=1
+build_src_filter = ${Station_G3_ESP32_r2.build_src_filter}
+  +<helpers/bridges/MQTTBridge.cpp>
+  +<helpers/MQTTMessageBuilder.cpp>
+  +<helpers/JWTHelper.cpp>
+  +<helpers/ui/SH1106Display.cpp>
+  +<helpers/SNMPAgent.cpp>
+  +<../examples/simple_room_server>
+lib_deps =
+  ${Station_G3_ESP32_r2.lib_deps}
   ${esp32_ota.lib_deps}
   elims/PsychicMqttClient@^0.2.4
   bblanchon/ArduinoJson @ 7.4.3


### PR DESCRIPTION
The motherboard has two RF daughterboard slots on separate GPIOs, mirrored by its "LNA P" / "LNA S" jumpers, but the variant only ever pinned slot 1.

The shared configuration moves into [Station_G3_ESP32_common], with the SPI and LNA lines split into per-slot sections. [Station_G3_ESP32] (slot 1) and [Station_G3_ESP32_r2] (slot 2) each compose common + their own pins, so neither set of -D flags has to shadow the other on the compile line - appending an override would work only by last-wins, and esp32_base's -w hides the resulting redefinition warning. Every pre-existing env keeps its name and resolves to byte-identical options; verified by diffing pio project config --json-output.

PA PL1 is one board-level jumper shared by both slots, so P_PA1_EN stays in the common section along with the TX power calibration.

Adds r2 twins of the repeater, room server and both observer envs, each an exact mirror of its slot-1 sibling apart from the base it extends.

Slot 2 pins come from on-hardware testing in agessaman/MeshCore#49.

Known limitation, unchanged from that PR: GPIO 42 and 43 fall outside the ESP32-S3 RTC GPIO range (0-21), so the rtc_gpio_hold_en() calls in ESP32Board::enterDeepSleep() and StationG3Board::powerOff() return ESP_ERR_INVALID_ARG on slot 2 and the NSS and LNA pins are not latched through deep sleep. Fixing it means gpio_hold_en() plus gpio_deep_sleep_hold_en() in shared code.