### PR TITLE
Add marwoj.net MQTT broker preset 🤖🤖

### DIFF
--- a/MQTT_IMPLEMENTATION.md
+++ b/MQTT_IMPLEMENTATION.md
@@ -163,6 +163,7 @@ below documents the current build.
 | `idahomesh` | `wss://mqtt.idahomesh.org:443/mqtt` | JWT | — |
 | `ntxmesh` | `wss://ntxmesh.dhovin.me:8883` | JWT | — |
 | `bsmesh` | `wss://mqtt.bsmesh.de:8885` | JWT | — |
+| `marwoj` | `mqtts://mqtt.marwoj.net:8883` | User/pass (in firmware) | — |
 | `custom` | your own broker | User/pass, or JWT when `mqttN.audience` is set | `set mqttN.server` (see [custom broker setup](#custom-brokers)) |
 | `none` | (slot disabled) | — | — |
 
@@ -370,7 +371,7 @@ Each slot (1-6) supports the following commands:
 - `set mqttN.audience` - Clear JWT audience (reverts to username/password auth)
 - `set mqttN.filter <all|none|list>` - Select payload types uploaded to this slot
 
-**Note:** Custom server/port settings only apply when the slot's preset is `custom`. Username/password also apply to built-in presets that use per-slot credentials (e.g. `inwmesh`); other userpass presets (`tennmesh`, `nashmesh`, `ctmesh`) ship fixed credentials in firmware.
+**Note:** Custom server/port settings only apply when the slot's preset is `custom`. Username/password also apply to built-in presets that use per-slot credentials (e.g. `inwmesh`); other userpass presets (`tennmesh`, `nashmesh`, `ctmesh`, `marwoj`) ship fixed credentials in firmware.
 
 #### Per-broker packet filters
 
@@ -889,7 +890,7 @@ the radio actually performs in that case.
 ### Authentication
 The auth mode is fixed per preset (see [Broker Presets](#broker-presets)). Three modes are used:
 - **JWT Authentication**: Ed25519-signed tokens for brokers that expect JWT (most WSS presets). For `custom` slots, JWT is used when `audience` is set.
-- **Username/Password**: Some presets ship fixed credentials embedded in firmware (`tennmesh`, `nashmesh`, `ctmesh` — plain MQTT, no TLS); others (`inwmesh`, `custom`) take per-slot credentials via `mqttN.username` / `mqttN.password`.
+- **Username/Password**: Some presets ship fixed credentials embedded in firmware (`tennmesh`, `nashmesh`, `ctmesh` — plain MQTT, no TLS; `marwoj` — MQTT over TLS); others (`inwmesh`, `custom`) take per-slot credentials via `mqttN.username` / `mqttN.password`.
 - **None**: `meshrank` (account token carried in the topic) and `eastidahomesh` connect without broker auth.
 - **Username Format** (JWT): `v1_{UPPERCASE_PUBLIC_KEY}`
 - **Automatic Token Renewal**: Tokens are renewed before expiration

--- a/src/helpers/MQTTPresets.h
+++ b/src/helpers/MQTTPresets.h
@@ -148,7 +148,7 @@ static const char ISRG_ROOT_X1[] PROGMEM =
     "-----END CERTIFICATE-----\n";
 
 // Number of built-in presets
-static const int MQTT_PRESET_COUNT = 36;
+static const int MQTT_PRESET_COUNT = 37;
 
 // Built-in preset definitions (stored in flash)
 static const MQTTPresetDef MQTT_PRESETS[MQTT_PRESET_COUNT] = {
@@ -197,6 +197,7 @@ static const MQTTPresetDef MQTT_PRESETS[MQTT_PRESET_COUNT] = {
     { "idahomesh",     "wss://mqtt.idahomesh.org:443/mqtt",       "mqtt.idahomesh.org",              ISRG_ROOT_X1,  MQTT_AUTH_JWT,      MQTT_TOPIC_MESHCORE,  0,       true,   55,      nullptr,     nullptr     },
     { "ntxmesh",       "wss://ntxmesh.dhovin.me:8883",            "ntxmesh.dhovin.me",               ISRG_ROOT_X1,  MQTT_AUTH_JWT,      MQTT_TOPIC_MESHCORE,  0,       true,   55,      nullptr,     nullptr     },
     { "bsmesh",        "wss://mqtt.bsmesh.de:8885",               "mqtt.bsmesh.de",                  ISRG_ROOT_X1,  MQTT_AUTH_JWT,      MQTT_TOPIC_MESHCORE,  0,       true,   55,      nullptr,     nullptr     },
+    { "marwoj",        "mqtts://mqtt.marwoj.net:8883",            nullptr,                           ISRG_ROOT_X1,  MQTT_AUTH_USERPASS,  MQTT_TOPIC_MESHCORE,  0,       true,   55,      "observer-agessaman", "ipRwCEclZkX47K" },
 };
 
 // Find a preset by name, returns nullptr if not found


### PR DESCRIPTION
## Summary

Adds a built-in MQTT preset for the Polish MeshCore community broker at
`mqtt.marwoj.net`.

The broker uses MQTT over TLS on port 8883 with username/password
authentication and the standard MeshCore topic layout, so users can
configure it with a single command:

```
set mqttN.preset marwoj
```

## Configuration

- Endpoint: `mqtts://mqtt.marwoj.net:8883`
- Authentication: username/password embedded in the preset, following the
  existing `tennmesh` / `nashmesh` / `ctmesh` pattern
- TLS CA: the existing `ISRG_ROOT_X1` constant (the server presents a valid
  Let's Encrypt chain, so no new CA certificate is added)
- Topic style: `MQTT_TOPIC_MESHCORE`, retain enabled, keepalive 55

The credentials are a dedicated public firmware account created for this
preset; they are intentionally not a private or admin credential.

## Changes

- `src/helpers/MQTTPresets.h` — add the `marwoj` entry and bump
  `MQTT_PRESET_COUNT` from 36 to 37
- `MQTT_IMPLEMENTATION.md` — add the broker to the presets table and to the
  two notes listing presets that ship fixed credentials in firmware

## Testing

- Endpoint and credentials tested on a physical MeshCore Observer device
  using the equivalent `custom` slot configuration: the slot came up as
  connected over TLS, authenticated successfully, and published without
  publish errors.
- TLS chain verified independently with `openssl s_client -verify_return_error`
  (verify return code 0).
- `pio run -e heltec_v4_repeater_observer_mqtt` builds clean with this change.
- The `native` gtest suite could not be run locally (no host compiler on this
  machine); the preset table was instead compile-checked with static asserts
  confirming `MQTT_PRESET_COUNT` matches the number of initialisers.
